### PR TITLE
Fix git dependencies issue of production target

### DIFF
--- a/production.xml
+++ b/production.xml
@@ -19,11 +19,11 @@
     <mkdir dir="${capstone}/../dist"/>
    
     <exec executable="sh" if:set="isZos">
-      <arg line="-c 'cp -pR ../* ${capstone}/../dist/'"/>
+      <arg line="-c 'cp -pR .. ${capstone}/../dist/'"/>
     </exec>
 	   
     <exec executable="sh" if:set="isUnix">
-      <arg line="-c 'cp -pR ../* ${capstone}/../dist/'"/>
+      <arg line="-c 'cp -pR .. ${capstone}/../dist/'"/>
     </exec>
 
     <copy todir="${capstone}/../dist/" if:set="isWindows">


### PR DESCRIPTION
Production target fails to build plugins having git+https dependencies
under Unix/Linux.

Signed-off-by: Dmitry Nikolaev <dnikolaev@rocketsoftware.com>