### PR TITLE
zss: remove non-Z copy, add permission

### DIFF
--- a/deploy.xml
+++ b/deploy.xml
@@ -116,9 +116,6 @@
             <exec executable="sh">
               <arg line="-c 'cp -pR externals/Rocket/zssServer ${home}/bin/zssServer'"/>
             </exec>
-            <exec executable="sh">
-              <arg line="-c 'extattr +p ${home}/bin/zssServer'"/>
-            </exec>
           </then>
         </if>
       </then>

--- a/deploy.xml
+++ b/deploy.xml
@@ -116,10 +116,10 @@
             <exec executable="sh">
               <arg line="-c 'cp -pR externals/Rocket/zssServer ${home}/bin/zssServer'"/>
             </exec>
+            <exec executable="sh">
+              <arg line="-c 'extattr +p ${home}/bin/zssServer'"/>
+            </exec>
           </then>
-          <else>
-            <copy file="externals/Rocket/zssServer" tofile="${home}/bin/zssServer"/>
-          </else>
         </if>
       </then>
     </if>


### PR DESCRIPTION
No sense in doing a copy of zssServer on non-Z systems. 
Remember to use extattr to set permission

Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>