### PR TITLE
Deploy APIML keystore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@
 npm-debug.log
 testem.log
 /typings
+build.log
 
 # e2e
 /e2e/*.js

--- a/build.sh
+++ b/build.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 # This program and the accompanying materials are
 # made available under the terms of the Eclipse Public License v2.0 which accompanies
 # this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
@@ -5,7 +6,6 @@
 # SPDX-License-Identifier: EPL-2.0
 # 
 # Copyright Contributors to the Zowe Project.
-#!/bin/sh
 ant buildAll
 
 # This program and the accompanying materials are

--- a/deploy.xml
+++ b/deploy.xml
@@ -87,6 +87,9 @@
         <include name="zluxserver.json"/>
         <include name="server.cert"/>
         <include name="server.key"/>
+        <include name="zlux.keystore.cer"/>
+        <include name="zlux.keystore.key"/>
+        <include name="apiml-localca.cer"/>
       </fileset>
     </copy>
     <exec if:set="isZos" executable="sh">
@@ -94,6 +97,9 @@
                   ${home}/config/zluxserver.json
                   ${home}/config/server.cert
                   ${home}/config/server.key
+                  ${home}/config/zlux.keystore.cer
+                  ${home}/config/zlux.keystore.key
+                  ${home}/config/apiml-localca.cer
                   ${deploy}/instance/ZLUX/serverConfig'"/>
     </exec>
 


### PR DESCRIPTION
This PR adds the APIML generated certificate to the list of files deployed 
by the deployment scripts.

Resolves https://github.com/zowe/api-layer/issues/92
Depends on https://github.com/zowe/zlux-example-server/pull/27
Depends on https://github.com/zowe/zlux-proxy-server/pull/34