### PR TITLE
Feature/npm ci

### DIFF
--- a/build_ng2.xml
+++ b/build_ng2.xml
@@ -156,14 +156,14 @@
           osfamily="windows"
           resultproperty="rc"
           searchpath="true">
-      <arg line="/c npm install"/>
+      <arg line="/c npm ci"/>
     </exec>
     <exec executable="npm" 
           dir="${packagejson.Location}"
           osfamily="unix"
           resultproperty="rc"
           searchpath="true">
-      <arg line="install"/>
+      <arg line="ci"/>
     </exec>
     
     <echo message="Result of install in ${packagejson.Location} is: ${rc}"/>

--- a/build_ng2.xml
+++ b/build_ng2.xml
@@ -209,7 +209,7 @@
   <target name="package.jsonExists">
     <available file="${packagejson.Location}/package.json" property="package.jsonPresent"/>
   </target>
-  
+ 
 </project>
 
 <!-- 

--- a/copy_node.xml
+++ b/copy_node.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0"?>
+
+<!-- 
+  This program and the accompanying materials are
+  made available under the terms of the Eclipse Public License v2.0 which accompanies
+  this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
+  
+  SPDX-License-Identifier: EPL-2.0
+  
+  Copyright Contributors to the Zowe Project.
+-->
+<project name="copy_node" default="copynode" xmlns:if="ant:if" xmlns:unless="ant:unless">
+  <import file="common.xml"/>
+  <target name="copynode">  
+    <mkdir dir="${user.dir}/../lib/node_modules/"/>
+    <copy todir="${user.dir}/../lib/node_modules/" if:set="isWindows"> <fileset dir ="${user.dir}/../nodeServer/node_modules"  includes="**" />
+    </copy>
+    <exec if:set="isUnix" executable="sh">
+      <arg line="-c 'cp -pR ${user.dir}/../nodeServer/node_modules/* ${user.dir}/../lib/node_modules/'"/>
+    </exec>   
+    <exec if:set="isZos" executable="sh">
+      <arg line="-c 'cp -pR ${user.dir}/../nodeServer/node_modules/* ${user.dir}/../lib/node_modules/'"/>
+    </exec>    
+  </target>
+</project>
+<!-- 
+  This program and the accompanying materials are
+  made available under the terms of the Eclipse Public License v2.0 which accompanies
+  this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
+  
+  SPDX-License-Identifier: EPL-2.0
+  
+  Copyright Contributors to the Zowe Project.
+-->


### PR DESCRIPTION
`npm ci` (doc: https://docs.npmjs.com/cli/ci.html) is a command that works like `npm install` except it cleans node_modules, and doesn't touch package*.json. This makes it suited to builds so that you can have repeatable results & no sandbox change as a result of a build. It also will not let you install if your package-lock does not match your package.json in terms of packages & versions. It is not suitable for updating dependencies on the other hand, as it doesn't update package-lock.json. So, let's use it for build, but still rely on `npm install` for development to keep package-locks up to date.
Depends on https://github.com/zowe/zlux-proxy-server/pull/48 because that repo had an out of date package-lock.json

**Note** This makes the minimum version of npm 5.7.0
