### PR TITLE
Path update for server rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ These scripts require at least version 1.9.1 of Apache Ant. ant-contrib is also 
 
 Use 'ant help' to get list of targets accessible from this directory
 
-The script has two primary parts: deploy and build. Deploy populates the deploy directory under zlux-example-server. Build will build the source of the file so it can be used within the brower
+The script has two primary parts: deploy and build. Deploy populates the deploy directory under zlux-app-server. Build will build the source of the file so it can be used within the brower
 
 The default behavior for a plugin is to navigate to its home directory, as defined by the directory given in its _pluginDefinition.json_ file, and then run _npm install_ and _npm run build_. This can be altered by adding a build/build.xml file to the plugin's home directory. Having a _deploy_ target in this file will cause it to be run during the deploy step. This is useful for adding plugin-specific configuration files. If there is a _build_ target in this file, it will be run instead of _npm install_ and _npm run build_. You can still call those functions within the _build_ target, but you can use ant to do whatever other build steps need to be done
 

--- a/build.xml
+++ b/build.xml
@@ -13,11 +13,11 @@
   <taskdef resource="net/sf/antcontrib/antlib.xml"/>
   <property environment="env"/>
   <property name="capstone" location="../"/>
-  <property name="zlux-example-server" value="${capstone}/zlux-example-server"/>
-  <property name="home" value="${zlux-example-server}"/>
+  <property name="zlux-app-server" value="${capstone}/zlux-app-server"/>
+  <property name="home" value="${zlux-app-server}"/>
   <property name="buildRel" value="zlux-build"/>
   <property name="build" value="${capstone}/zlux-build"/>
-  <property name="deploy" value="${zlux-example-server}/deploy"/>
+  <property name="deploy" value="${zlux-app-server}/deploy"/>
 
   <import file="common.xml" unless:set="version.date"/>
 

--- a/build_ng2.xml
+++ b/build_ng2.xml
@@ -35,7 +35,7 @@
         <dirset dir="${capstone}">
           <include name="**/.*"/>
           <include name="**/node_modules"/>
-          <exclude name="zlux-proxy-server/js/node_modules/**"/>
+          <exclude name="zlux-server-framework/js/node_modules/**"/>
         </dirset>
         <dirset dir="${capstone}">
           <include name="**/src"/>
@@ -45,12 +45,12 @@
           <exclude name="sample-*/**"/>
           <exclude name="zlux-app-manager/virtual-desktop/**"/>
           <exclude name="zlux-platform/interface/**"/>
-          <exclude name="zlux-proxy-server/js/node_modules/**"/>
+          <exclude name="zlux-server-framework/js/node_modules/**"/>
           <exclude name="zlux-shared/**"/>
         </dirset>
         <fileset dir="${capstone}" defaultexcludes="false">
           <include name="**/.*"/>
-          <exclude name="zlux-proxy-server/js/node_modules/**"/>
+          <exclude name="zlux-server-framework/js/node_modules/**"/>
         </fileset>
         <fileset dir="${capstone}" defaultexcludes="false">
           <include name="**/*.ts"/>
@@ -58,7 +58,7 @@
           <include name="**/tsconfig*.json"/>
           <include name="**/tslint.json"/>
           <include name="**/webpack.config.js"/>
-          <exclude name="zlux-example-server/**"/>
+          <exclude name="zlux-app-server/**"/>
           <exclude name="zlux-build/**"/>
           <exclude name="**/node_modules/**"/>
           <exclude name="sample-*/**"/>
@@ -125,7 +125,7 @@
   
   <target name="bootstrapBuild"><!--We could pass different args for bootstrap if we wanted-->
     <antcall target="npmInstall" unless:set="noInstall">  
-      <param name="packagejson.Location" value="${capstone}/zlux-proxy-server/js"/>
+      <param name="packagejson.Location" value="${capstone}/zlux-server-framework/js"/>
     </antcall>
     <antcall target="npmInstall" unless:set="noInstall">
       <param name="packagejson.Location" value="${capstone}/zlux-app-manager/bootstrap"/>

--- a/common.properties
+++ b/common.properties
@@ -1,1 +1,1 @@
-plugins=../zlux-example-server/plugins
+plugins=../zlux-app-server/plugins

--- a/core-plugins.properties
+++ b/core-plugins.properties
@@ -3,6 +3,6 @@ CORE_PLUGINS=zlux-shared/src/logging/package.json,\
  zlux-app-manager/bootstrap/pluginDefinition.json,\
  zlux-app-manager/virtual-desktop/package.json,\
  zlux-app-manager/virtual-desktop/pluginDefinition.json,\
- zlux-proxy-server/js/package.json,\
- zlux-proxy-server/plugins/config/pluginDefinition.json,\
- zlux-proxy-server/plugins/terminal-proxy/pluginDefinition.json
+ zlux-server-framework/js/package.json,\
+ zlux-server-framework/plugins/config/pluginDefinition.json,\
+ zlux-server-framework/plugins/terminal-proxy/pluginDefinition.json


### PR DESCRIPTION
Updates paths for renaming from example-server to app-server, proxy-server to server-framework
Do not merge this until https://github.com/zowe/zlux is updated to have the new folder names as well. I will coordinate.
Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>