### PR TITLE
Set server configuration file permissions

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -68,6 +68,9 @@ cp -v ../tn3270-ng2/_defaultTN3270.json ../zlux-app-server/deploy/instance/ZLUX/
 mkdir -p ../zlux-app-server/deploy/instance/ZLUX/pluginStorage/org.zowe.terminal.vt
 mkdir -p ../zlux-app-server/deploy/instance/ZLUX/pluginStorage/org.zowe.terminal.vt/sessions
 cp -v ../vt-ng2/_defaultVT.json ../zlux-app-server/deploy/instance/ZLUX/pluginStorage/org.zowe.terminal.vt/sessions/_defaultVT.json
+
+chmod -R go-w ../zlux-app-server/deploy/instance/ZLUX/serverConfig
+chmod -R o-rx ../zlux-app-server/deploy/instance/ZLUX/serverConfig
 # This program and the accompanying materials are
 # made available under the terms of the Eclipse Public License v2.0 which accompanies
 # this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html

--- a/deploy.xml
+++ b/deploy.xml
@@ -45,9 +45,6 @@
     <property name="siteRecognizers" value="${deploy}/site/ZLUX/pluginStorage/org.zowe.zlux.ng2desktop/recognizers"/>
     <mkdir dir="${siteActions}"/>
     <mkdir dir="${siteRecognizers}"/>
-    
-    <!-- for demonstration purposes -->
-    <mkdir dir="${deploy}/site/ZLUX/pluginStorage/com.rs.dsnchangeview/query"/>
 
     <mkdir dir="${deploy}/instance/ZLUX/plugins"/>
     <mkdir dir="${deploy}/instance/ZLUX/pluginStorage"/>
@@ -110,18 +107,21 @@
 
     <antcall target="traverse"/>
     <if>
-      <available file="externals/Rocket/zssServer"/>
+      <available file="../zss/bin/zssServer"/>
       <then>
         <if>
           <isset property="isZos"/>
           <then>
             <exec executable="sh">
-              <arg line="-c 'cp -pR externals/Rocket/zssServer ${home}/bin/zssServer'"/>
+              <arg line="-c 'cp -pR ../zss/bin/zssServer ${home}/bin/zssServer'"/>
             </exec>
           </then>
         </if>
       </then>
     </if>
+
+    <chmod unless:set="isWindows" dir="${deploy}/instance/ZLUX/serverConfig" perm="go-w" includes="**/*"/>
+    <chmod unless:set="isWindows" dir="${deploy}/instance/ZLUX/serverConfig" perm="o-rx" includes="**/*"/>      
   </target>
 
   <target name="cleanDeploy">

--- a/deploy.xml
+++ b/deploy.xml
@@ -120,8 +120,10 @@
       </then>
     </if>
 
-    <chmod unless:set="isWindows" dir="${deploy}/instance/ZLUX/serverConfig" perm="go-w" includes="**/*"/>
-    <chmod unless:set="isWindows" dir="${deploy}/instance/ZLUX/serverConfig" perm="o-rx" includes="**/*"/>      
+    <chmod unless:set="isWindows" dir="${deploy}/instance/ZLUX/serverConfig" perm="750"/>
+    <chmod unless:set="isWindows" perm="640">
+      <fileset dir="${deploy}/instance/ZLUX/serverConfig"/>
+    </chmod>
   </target>
 
   <target name="cleanDeploy">


### PR DESCRIPTION
For security, the server's configuration directory shouldn't be editable by anyone other than the server user. People in the group (ideally, zowe admin group) can read it. But, others outside the group can't access these files at all.
Also noticed the ant deploy (dev deploy) was referencing zss in an old location, so that got updated to the most likely spot that you'd find zss if it were present.