### PR TITLE
Removing security changes here so that they can be done in zowe installer repo

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -30,6 +30,9 @@
 # serverConfig - the folder for storing information that the server needs at startup, such as a json describing
 #                the port to use, or other files for security certificates
 
+# Don't do permission changes in this script because final changes such as these happen after this script is executed
+# Such as, currently in zowe-runtime-authorize.sh
+
 mkdir -p ../zlux-app-server/deploy/product
 mkdir -p ../zlux-app-server/deploy/product/ZLUX
 mkdir -p ../zlux-app-server/deploy/product/ZLUX/plugins
@@ -68,9 +71,6 @@ cp -v ../tn3270-ng2/_defaultTN3270.json ../zlux-app-server/deploy/instance/ZLUX/
 mkdir -p ../zlux-app-server/deploy/instance/ZLUX/pluginStorage/org.zowe.terminal.vt
 mkdir -p ../zlux-app-server/deploy/instance/ZLUX/pluginStorage/org.zowe.terminal.vt/sessions
 cp -v ../vt-ng2/_defaultVT.json ../zlux-app-server/deploy/instance/ZLUX/pluginStorage/org.zowe.terminal.vt/sessions/_defaultVT.json
-
-chmod -R go-w ../zlux-app-server/deploy/instance/ZLUX/serverConfig
-chmod -R o-rx ../zlux-app-server/deploy/instance/ZLUX/serverConfig
 # This program and the accompanying materials are
 # made available under the terms of the Eclipse Public License v2.0 which accompanies
 # this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html


### PR DESCRIPTION
Discussed installers with Joe W and Matt H and found that we shouldn't be doing permission changes in zlux-build if they are instead doing to be done in zowe-install-packaging (most likely, in https://github.com/zowe/zowe-install-packaging/blob/master/scripts/zowe-runtime-authorize.sh).
So, this reverts the file permission modifications here so that they can be done elsewhere.
Signed-off-by: Sean Grady <sgrady@rocketsoftware.com>