### PR TITLE
Adding shared lib

### DIFF
--- a/build_ng2.xml
+++ b/build_ng2.xml
@@ -22,6 +22,13 @@
       <param name="packagejson.Location" value="${capstone}/zlux-shared/src/logging"/>
       <param name="buildType" value="build"/>
     </antcall>
+    <antcall target="npmInstall">
+      <param name="packagejson.Location" value="${capstone}/zlux-shared/src/obfuscator"/>
+    </antcall>
+    <antcall target="npmBuild">
+      <param name="packagejson.Location" value="${capstone}/zlux-shared/src/obfuscator"/>
+      <param name="buildType" value="build"/>
+    </antcall>    
     
     <copy file="${capstone}/zlux-app-manager/virtual-desktop/node_modules/requirejs/require.js" tofile="${capstone}/zlux-app-manager/virtual-desktop/web/require.js" unless:set="isZos"/>
     

--- a/core-plugins.properties
+++ b/core-plugins.properties
@@ -1,4 +1,5 @@
 CORE_PLUGINS=zlux-shared/src/logging/package.json,\
+ zlux-shared/src/obfuscator/package.json,\
  zlux-app-manager/bootstrap/package.json,\
  zlux-app-manager/bootstrap/pluginDefinition.json,\
  zlux-app-manager/virtual-desktop/package.json,\


### PR DESCRIPTION
Obfuscator code used to prevent XSS injection is being used by multiple plugins, so we need to build it here just like the logger.
Signed-off-by: Sean Grady <sgrady@rocketsoftware.com>