### PR TITLE
Build doesn't operate on correct plugin list due to deploy

### DIFF
--- a/deploy.xml
+++ b/deploy.xml
@@ -28,6 +28,12 @@
   </condition>
 
   <target name="deploy">
+    <delete quiet="true" dir="${deploy}/product/ZLUX/plugins"/>
+    <delete quiet="true" dir="${deploy}/instance/ZLUX/plugins"/>
+    <delete quiet="true" dir="${deploy}/site/ZLUX/plugins"/>
+    <delete quiet="true" includeEmptyDirs="true">
+      <fileset dir="${deploy}" includes="instance/users/*/ZLUX, instance/groups/*/ZLUX"/>
+    </delete>
     <mkdir dir="${deploy}/product/ZLUX/plugins"/>
     <mkdir dir="${deploy}/product/ZLUX/pluginStorage"/>
     <mkdir dir="${deploy}/product/ZLUX/serverConfig"/>
@@ -73,10 +79,10 @@
     </exec>
 
     <copy unless:set="isZos" todir="${deploy}/instance/ZLUX/plugins">
-      <fileset dir="${deploy}/product/ZLUX/plugins"/>
+      <fileset dir="${pluginDir}" includes="*.json"/>
     </copy>
     <exec if:set="isZos" executable="sh">
-      <arg line="-c 'cp -pR ${deploy}/product/ZLUX/plugins/ ${deploy}/instance/ZLUX/plugins'"/>
+      <arg line="-c 'cp -pR ${pluginDir}/*.json ${deploy}/instance/ZLUX/plugins'"/>
     </exec>
     
     <copy unless:set="isZos" todir="${deploy}/instance/ZLUX/serverConfig">


### PR DESCRIPTION
Plugin folders within the deploy structure are now deleted before copying from the root plugin folder so that users do not manually have to clean out their plugin folders.  Further, deploy/instance now receives its contents from plugin directory, rather than from deploy/product.

Signed-off-by: Timothy Gerstel <tgerstel@rocketsoftware.com>