### PR TITLE
Allow absolute directories to be built

### DIFF
--- a/build_ng2.xml
+++ b/build_ng2.xml
@@ -104,7 +104,12 @@
   </target>
   
   <target name="buildPlugin" depends="antPlugin" unless="build.xmlRan">
-    <property name="absolutePlugin" location="${pluginDir}/${plugin}"/>
+    <condition property="absolute">
+      <matches string="${plugin}" pattern="^\/"/>
+    </condition>
+    <property name="plugin.directory" value="${pluginDir}/${plugin}" unless:set="absolute"/>
+    <property name="plugin.directory" value="${plugin}" if:set="absolute"/>
+    
     <if>
       <not>
         <or>
@@ -114,18 +119,18 @@
       </not>
       <then>
         <antcall target="npmInstall" unless:set="noInstall">
-          <param name="packagejson.Location" value="${pluginDir}/${plugin}"/>
+          <param name="packagejson.Location" value="${plugin.directory}"/>
         </antcall>
         <antcall target="npmBuild">
-          <param name="packagejson.Location" value="${pluginDir}/${plugin}"/>
+          <param name="packagejson.Location" value="${plugin.directory}"/>
           <param name="buildType" value="build"/>
         </antcall>
       </then>
     </if>
-  
+    
     <for param="subfolder">
       <path>
-        <dirset dir="${pluginDir}/${plugin}" includes="*"/>
+        <dirset dir="${plugin.directory}" includes="*"/>
       </path>
       <sequential>
         <antcall target="npmInstall" unless:set="noInstall">


### PR DESCRIPTION
The install-app script would make apps that have absolute paths, which the scripting in here did not seem to support for building.
Getting ant to deal with absolute paths seems a bit odd, so this supports unix/linux/zos, but not windows. Windows behavior should not have regressed, however.
Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>