### PR TITLE
Production no deploy

### DIFF
--- a/production.xml
+++ b/production.xml
@@ -40,7 +40,6 @@
     </for>
 	  
     <ant antfile="build.xml" dir="${capstone}/../dist/${buildRel}" inheritAll="false">
-      <target name="deploy"/>
       <target name="build"/>
       <target name="removeSource"/>
       <property name="plugins" value="${plugins}"/>


### PR DESCRIPTION
Do not do deploy in production, it is no longer needed
It appears to just make duplicate folders that are not read in a 1.8+ install.