### PR TITLE
Add conda builder

### DIFF
--- a/conda/bld.bat
+++ b/conda/bld.bat
@@ -1,0 +1,18 @@
+@echo off
+REM This program and the accompanying materials are
+REM made available under the terms of the Eclipse Public License v2.0 which accompanies
+REM this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
+REM 
+REM SPDX-License-Identifier: EPL-2.0
+REM 
+REM Copyright Contributors to the Zowe Project.
+
+
+if not exist %PREFIX%\share\zowe\app-server\zlux-app-server\defaults\plugins mkdir %PREFIX%\share\zowe\app-server\zlux-app-server\defaults\plugins
+echo '{"identifier":"%PKG_NAME%","pluginLocation":"%PREFIX%/share/zowe/app-server/plugins/%PKG_NAME%/%PKG_VERSION%"}' ^
+     > %PREFIX%\share\zowe\app-server\zlux-app-server\defaults\plugins\%PKG_NAME%.json
+
+if not exist %PREFIX%\share\zowe\app-server\plugins\%PKG_NAME%\%PKG_VERSION% mkdir %PREFIX%\share\zowe\app-server\plugins\%PKG_NAME%\%PKG_VERSION%
+robocopy %SRC_DIR% %PREFIX%\share\zowe\app-server\plugins\%PKG_NAME%\%PKG_VERSION% * /E > nul
+
+exit 0

--- a/conda/build.sh
+++ b/conda/build.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+# This program and the accompanying materials are
+# made available under the terms of the Eclipse Public License v2.0 which accompanies
+# this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
+# 
+# SPDX-License-Identifier: EPL-2.0
+# 
+# Copyright Contributors to the Zowe Project.
+
+mkdir -p $PREFIX/share/zowe/app-server/plugins/$PKG_NAME/$PKG_VERSION
+cp -r ${SRC_DIR}/* $PREFIX/share/zowe/app-server/plugins/$PKG_NAME/$PKG_VERSION
+mkdir -p $PREFIX/share/zowe/app-server/zlux-app-server/defaults/plugins
+echo "{\"identifier\":\"${PKG_NAME}\",\"pluginLocation\":\"${PREFIX}/share/zowe/app-server/plugins/${PKG_NAME}/${PKG_VERSION}\"}" \
+     > $PREFIX/share/zowe/app-server/zlux-app-server/defaults/plugins/${PKG_NAME}.json
+
+cd $PREFIX/share/zowe/app-server/plugins/$PKG_NAME/$PKG_VERSION
+rm -f build_env_setup.sh conda_build.sh metadata_conda_debug.yaml *.ppf
+
+exit 0

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,0 +1,30 @@
+{% set data = load_setup_py_data(setup_file='./setup.py', from_recipe_dir=True) %}
+
+# This program and the accompanying materials are
+# made available under the terms of the Eclipse Public License v2.0 which accompanies
+# this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
+# 
+# SPDX-License-Identifier: EPL-2.0
+# 
+# Copyright Contributors to the Zowe Project.
+
+package:
+  name: "{{ data.get('name')|lower }}"
+  version: "{{ data.get('version') }}"
+
+source:
+  path: ../../plugin
+
+build:
+  number: "{{ data.get('buildnumber') }}"
+  string: "zowe"
+  {{ data.get('noarch') }}
+#  features:
+#    - zowe
+
+about:
+  home: "{{ data.get('homepage') }}"
+  license: "{{ data.get('license') }}"
+  license_file: "LICENSE"
+  summary: "{{ data.get('description') }}"
+  doc_url: "https://docs.zowe.org"

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -18,7 +18,8 @@ source:
 build:
   number: "{{ data.get('buildnumber') }}"
   string: "zowe"
-  {{ data.get('noarch') }}
+{{ data.get('noarch') }}
+
 #  features:
 #    - zowe
 

--- a/conda/setup.py
+++ b/conda/setup.py
@@ -1,0 +1,51 @@
+from distutils.core import setup
+import json
+import os
+import sys
+import glob
+# This program and the accompanying materials are
+# made available under the terms of the Eclipse Public License v2.0 which accompanies
+# this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
+# 
+# SPDX-License-Identifier: EPL-2.0
+# 
+# Copyright Contributors to the Zowe Project.
+
+print('Loading package attributes from pluginDefinition.json')
+with open('./plugin/pluginDefinition.json', 'r') as f:
+  pluginDef = json.load(f)
+  if ('license' in pluginDef):
+      license = pluginDef['license']
+  else:
+      license = "UNKNOWN"
+
+  if ('webContent' in pluginDef):
+      if ('descriptionDefault' in pluginDef['webContent']):
+          description=pluginDef['webContent']['descriptionDefault']
+      else:
+          description=""
+  else:
+      description=""
+
+  if ('homepage' in pluginDef):
+    homepage=pluginDef['homepage']
+  else:
+    homepage=""
+
+  if ('descriptionDefault' in pluginDef):
+      description = pluginDef['descriptionDefault']
+
+  buildnumber=os.getenv('ZLUX_BUILD_NUMBER')
+      
+  if (sys.platform != 'zos'):
+    noarch="noarch: generic"
+
+  setup(name=pluginDef['identifier'],
+        version=pluginDef['pluginVersion'],
+        description=description,
+        license=license,
+        homepage=homepage,
+        noarch=noarch,
+        buildnumber=buildnumber )
+  
+#    uiVersion=f"- zowe-ui {uiVersion}"

--- a/conda/setup.py
+++ b/conda/setup.py
@@ -38,7 +38,9 @@ with open('./plugin/pluginDefinition.json', 'r') as f:
   buildnumber=os.getenv('ZLUX_BUILD_NUMBER')
       
   if (sys.platform != 'zos'):
-    noarch="noarch: generic"
+    noarch="  noarch: generic"
+  else:
+    noarch="# zos build"
 
   setup(name=pluginDef['identifier'],
         version=pluginDef['pluginVersion'],


### PR DESCRIPTION
Simple conda build scripts: given a folder of a previously built plugin, get its metadata and build a conda package by just copying it into a destination.
Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>