### PR TITLE
Conda zowe install automation and readme

### DIFF
--- a/conda/README.md
+++ b/conda/README.md
@@ -1,0 +1,192 @@
+# Conda for Package Managment of Zowe Plugins
+
+As Zowe is composed of components which can be extended by plugins, 
+A standardized and simple way to find, install, upgrade, and list plugins in your Zowe environment
+Is important to make it easy to get the most out of Zowe.
+
+Package management as a concept generally provides a way to find packages such as plugins,
+Check and possible co-install dependencies the package has, and ultimately install the desired package.
+Post-install, management tasks such as upgrading and uninstalling are common.
+
+Conda is one such package manager, and if you are familiar with apt, yum, or npm, you will find
+That using conda is very similar. But, there are some important abilities that make conda stand out:
+
+* Very cross platform: Conda is available, and acts very similar on z/OS, Windows, Linux, mac OS, and various Unix.
+                       Packages can state which platforms they support, so it easy to know what packages you can install.
+* Tagging: On z/OS, conda packages can contain tagging information, to avoid issues around the difference between EBCDIC & ASCII
+* Software neutrality: Language-specific package managers are becoming popular, but Conda does not assume the purpose of the package, so you can install most anything.
+* Environments: If desired, every user can have a different set of packages, because conda can install & manage packages in personal folders instead of system ones.
+                A user can even have multiple such environments, and switch between them rapidly to work with different sets of related software without conflict.
+
+
+## Initial Conda Setup
+
+If you have not installed Conda yet, it can be downloaded as an all-in-one package that has no extra dependencies, known as "miniconda".
+For Linux, Unix, and Windows, this can be downloaded at https://docs.conda.io/en/latest/miniconda.html
+For z/OS, Conda can be downloaded from Rocket Software at https://www.rocketsoftware.com/zos-open-source
+
+Conda will prompt during the install for certain setup options, 
+And ultimately you'll want to put some conda initialization content into your startup script
+So that whenever you open your terminal, conda will be ready for your use.
+
+Once you have conda downloaded and installed, you'll want to create your first conda "environment"
+This can be done by providing a path or a nickname
+
+`conda create --prefix PATH`
+`conda create --name ENVIRONMENT`
+
+Either will work, but path helps you better seperate your content from content others use by placing it in a folder that you can have stricter permissions on.
+
+If you need to know more about certain commands, you can use the help command for any.
+
+`conda create --help`
+
+Or, check the official documentation: https://docs.conda.io/en/latest/index.html
+
+Once you have an environment, you should activate it so that the actions you do are on that environment, as opposed to the base one.
+
+`conda activate PATH_OR_NAME`
+
+Conda will detect whether the parameter is a path or a nickname, so this command works for both.
+
+Finally, you can view the conda environment and other information by checking "info"
+`conda info`
+
+## Managing Conda Channels
+
+When downloading a package, such as a Zowe Plugin, the place that you download from is configurable.
+These are called "Channels", but are very similar to "Repositories" seen in other package managers.
+With Conda, you can install from:
+
+* A network channel (Internet or company internal)
+* A local channel (Collection of plugins on your computer)
+* Just an individual package, without a channel
+
+You can have multiple of each, and if a package is present in more than one location, you can specify which one to use.
+
+## Searching for Packages
+
+Conda has a search utility that checks all the Channels, but it's important to note that because any type of software
+Can be installed through Conda, that you probably want to search through the details to help identify which ones are meant for Zowe,
+Or use Channels that are distinctly for Zowe so that you can get packages that are strictly for Zowe.
+
+`conda search anything_you_want`
+`conda search --info this_gives_more_details`
+
+## Using Conda with Zowe
+
+Zowe is not yet available in the form of conda packages yet, so it must be installed separately.
+If you have Zowe installed on the same system as Conda, some Zowe plugins installed through Conda will automatically register into Zowe.
+In order to do this, the plugins must be able to find Zowe. You should set environment variables before trying to install the plugins:
+
+### Setting environment variables temporarily:
+z/OS, Linux, Unix:
+```
+export ZOWE_INSTANCE_DIR=/path/to/zowe/instance
+export ZOWE_ROOT_DIR=/path/to/zowe/installation
+```
+
+Windows cmd.exe:
+```
+set ZOWE_INSTANCE_DIR=\path\to\zowe\instance
+set ZOWE_ROOT_DIR=\path\to\zowe\installation
+```
+
+`INSTANCE_DIR` and `ROOT_DIR` are also supported, but the `ZOWE_` prefix helps distinguish its purpose.
+
+### Setting environment variables persistently:
+z/OS, Linux, Unix:
+You can put the `export` statements into the `.profile` file in your home directory to have them apply on login.
+
+Windows:
+There is a UI to set variables, but it varies depending on Windows version.
+Try typing 'environment variable' into the Windows search bar to get to the relevant menu.
+
+### Installing a Zowe Plugin
+
+A Conda package could contain one or more Zowe Plugins, and a Conda package could contain non-Zowe code alongside Zowe Plugins.
+This is left up to the program vendor, and regardless the install process is the same:
+
+`conda install package_name`
+
+If the Zowe environment variables are set, such a package may automatically register plugins into the Zowe instance of your choice.
+
+### Zowe Plugin Configuration
+
+Aside from possible automation during install and uninstall, Conda does not manage Zowe, its configuration, or configuration of the Plugins.
+However, Conda does manage the package files, and therefore you can do additional Zowe tasks on the Plugins by going into the Conda environment.
+Zowe Plugins are intended to be found in a standardized location in the Conda environment,
+
+`/opt/zowe/plugins`
+
+This folder contains plugins, which in turn contain sub-folders that are the Zowe components that they utilize.
+If a plugin uses multiple Zowe components, its contents could be found within multiple component folders.
+
+`/opt/zowe/plugins/my_plugin/app-server`
+`/opt/zowe/plugins/my_plugin/cli`
+
+### Zowe Package Structure
+
+Zowe Plugins packaged into Conda follow the structure outlined here: https://github.com/zowe/zowe-install-packaging/issues/1569
+This structure allows for plugin to have content meant for one or more Zowe components.
+The Conda packages extend this by allowing for more than one Plugin, or a mix of Zowe Plugins and other software to be within a single package.
+
+## Building Conda Packages for Zowe
+
+This document is intended to be provided with example scripts by the Zowe community, which shows you how you can build a simple Zowe plugin into a Conda package.
+This is not intended to be a one-size-fits-all set of scripts. If you have more advanced needs, you can use these scripts as a basis for writing your own scripts.
+
+To make a Conda package, you need conda-build, which you can install into a Conda environment:
+
+`conda install conda-build`
+
+Once you have it, you can build a package via
+
+`conda build path/to/build/scripts`
+
+However, first you must set up the build information.
+
+### Defining package properties
+Conda needs a metadata file, `meta.yaml` to state information about the package, such as dependencies, what OS it supports, its name and version.
+This information can be programmatically found, and Zowe provides examples of how to do this by reading Zowe's own metadata files into this one.
+
+### Creating Build Step
+It's recommended not to build your code from scratch to put into Conda.
+Rather, build your code however you want, and then just copy the contents into a conda package. This keeps the Conda scripting small and simple.
+
+In the same folder as `meta.yaml`, Conda requires `build.sh` for building on Unix, Linux, or z/OS and `build.bat` for Windows.
+Except for z/OS, this script does not determine where your package can be used, it's just about where you are building it.
+z/OS is the exception because when you build on z/OS, unix file tagging information is preserved. 
+So, it's highly recommended that you tag your files so that users do not have to deal with encoding issues.
+For code that works equally well on all platforms, a simple way to build for all is:
+1. Build your code on Linux
+1. Transfer the output to z/OS
+1. Run a Conda build on the output on Linux
+1. Run a Conda build on the output on z/OS
+1. Deliver the Linux package as 'noarch' content, and the z/OS package as 'zos-z' content.
+
+### Lifecycle Scripts
+When a Conda package is installed or uninstalled, a script from the package can be run.
+For Zowe, the scripts `post-link.sh` and `pre-unlink.sh` can be important, and you must put them into the same folder as `meta.yaml` for building.
+
+#### Install automation
+`post-link.sh` runs at install, after Conda has put the package content onto the system. 
+At this time, registration into Zowe is recommended if the Plugin does not require any information from the user for configuration.
+If the Plugin is okay to be automatically installed, we recommend putting a script into the package folder named `autoinstall.sh`
+Zowe's provided Conda examples will utilize `autoinstall.sh` to do any install steps your package needs, and provides Zowe information to make install simple.
+However, it's possible to do what you want in your own `post-link.sh` script instead.
+
+#### Uninstall automation
+`pre-unlink.sh` is the opposite of `post-link.sh`. It allows you to do anything you need to before the package is removed from the system.
+This is a good time to remove any package information from Zowe, but you should be careful because users may uninstall and later re-install,
+So you should not remove configuration information without consent.
+
+### Adding Configuration to Conda Packages
+As a package manager, Conda is not responsible for configuration. Your packages can include defaults to utilize, 
+But if configuration is needed you should alert the user to perform a post-install task. `post-link.sh` could be used to print such an alert.
+
+
+
+
+
+

--- a/conda/README.md
+++ b/conda/README.md
@@ -1,21 +1,21 @@
 # Conda for Package Managment of Zowe Plugins
 
 As Zowe is composed of components which can be extended by plugins, 
-A standardized and simple way to find, install, upgrade, and list plugins in your Zowe environment
-Is important to make it easy to get the most out of Zowe.
+a standardized and simple way to find, install, upgrade, and list plugins in your Zowe environment
+is important to make it easy to get the most out of Zowe.
 
 Package management as a concept generally provides a way to find packages such as plugins,
-Check and possible co-install dependencies the package has, and ultimately install the desired package.
+check and possible co-install dependencies the package has, and ultimately install the desired package.
 Post-install, management tasks such as upgrading and uninstalling are common.
 
 Conda is one such package manager, and if you are familiar with apt, yum, or npm, you will find
-That using conda is very similar. But, there are some important abilities that make conda stand out:
+that using Conda is very similar. But, there are some important abilities that make Conda stand out:
 
-* Very cross platform: Conda is available, and acts very similar on z/OS, Windows, Linux, mac OS, and various Unix.
+* Very cross platform: Conda is available, and acts very similar on z/OS, Windows, Linux, macOS, and various Unix.
                        Packages can state which platforms they support, so it easy to know what packages you can install.
-* Tagging: On z/OS, conda packages can contain tagging information, to avoid issues around the difference between EBCDIC & ASCII
+* Tagging: On z/OS, Conda packages can contain tagging information, to avoid issues around the difference between EBCDIC & ASCII.
 * Software neutrality: Language-specific package managers are becoming popular, but Conda does not assume the purpose of the package, so you can install most anything.
-* Environments: If desired, every user can have a different set of packages, because conda can install & manage packages in personal folders instead of system ones.
+* Environments: If desired, every user can have a different set of packages, because Conda can install & manage packages in personal folders instead of system ones.
                 A user can even have multiple such environments, and switch between them rapidly to work with different sets of related software without conflict.
 
 
@@ -26,11 +26,11 @@ For Linux, Unix, and Windows, this can be downloaded at https://docs.conda.io/en
 For z/OS, Conda can be downloaded from Rocket Software at https://www.rocketsoftware.com/zos-open-source
 
 Conda will prompt during the install for certain setup options, 
-And ultimately you'll want to put some conda initialization content into your startup script
-So that whenever you open your terminal, conda will be ready for your use.
+and ultimately you'll want to put some Conda initialization content into your startup script
+so that whenever you open your terminal, Conda will be ready for your use.
 
-Once you have conda downloaded and installed, you'll want to create your first conda "environment"
-This can be done by providing a path or a nickname
+Once you have Conda downloaded and installed, you'll want to create your first Conda "environment"
+this can be done by providing a path or a nickname
 
 `conda create --prefix PATH`
 `conda create --name ENVIRONMENT`
@@ -49,7 +49,7 @@ Once you have an environment, you should activate it so that the actions you do 
 
 Conda will detect whether the parameter is a path or a nickname, so this command works for both.
 
-Finally, you can view the conda environment and other information by checking "info"
+Finally, you can view the Conda environment and other information by checking "info"
 `conda info`
 
 ## Managing Conda Channels
@@ -67,15 +67,15 @@ You can have multiple of each, and if a package is present in more than one loca
 ## Searching for Packages
 
 Conda has a search utility that checks all the Channels, but it's important to note that because any type of software
-Can be installed through Conda, that you probably want to search through the details to help identify which ones are meant for Zowe,
-Or use Channels that are distinctly for Zowe so that you can get packages that are strictly for Zowe.
+can be installed through Conda, that you probably want to search through the details to help identify which ones are meant for Zowe,
+or use Channels that are distinctly for Zowe so that you can get packages that are strictly for Zowe.
 
 `conda search anything_you_want`
 `conda search --info this_gives_more_details`
 
 ## Using Conda with Zowe
 
-Zowe is not yet available in the form of conda packages yet, so it must be installed separately.
+Zowe is not yet available in the form of Conda packages yet, so it must be installed separately.
 If you have Zowe installed on the same system as Conda, some Zowe plugins installed through Conda will automatically register into Zowe.
 In order to do this, the plugins must be able to find Zowe. You should set environment variables before trying to install the plugins:
 
@@ -152,7 +152,7 @@ This information can be programmatically found, and Zowe provides examples of ho
 
 ### Creating Build Step
 It's recommended not to build your code from scratch to put into Conda.
-Rather, build your code however you want, and then just copy the contents into a conda package. This keeps the Conda scripting small and simple.
+Rather, build your code however you want, and then just copy the contents into a Conda package. This keeps the Conda scripting small and simple.
 
 In the same folder as `meta.yaml`, Conda requires `build.sh` for building on Unix, Linux, or z/OS and `build.bat` for Windows.
 Except for z/OS, this script does not determine where your package can be used, it's just about where you are building it.
@@ -179,11 +179,11 @@ However, it's possible to do what you want in your own `post-link.sh` script ins
 #### Uninstall automation
 `pre-unlink.sh` is the opposite of `post-link.sh`. It allows you to do anything you need to before the package is removed from the system.
 This is a good time to remove any package information from Zowe, but you should be careful because users may uninstall and later re-install,
-So you should not remove configuration information without consent.
+so you should not remove configuration information without consent.
 
 ### Adding Configuration to Conda Packages
 As a package manager, Conda is not responsible for configuration. Your packages can include defaults to utilize, 
-But if configuration is needed you should alert the user to perform a post-install task. `post-link.sh` could be used to print such an alert.
+but if configuration is needed you should alert the user to perform a post-install task. `post-link.sh` could be used to print such an alert.
 
 
 

--- a/conda/README.md
+++ b/conda/README.md
@@ -1,7 +1,7 @@
 # Conda for Package Managment of Zowe Plugins
 
-As Zowe is composed of components which can be extended by plugins, 
-a standardized and simple way to find, install, upgrade, and list plugins in your Zowe environment
+As Zowe is composed of components which can be extended by Plugins, 
+a standardized and simple way to find, install, upgrade, and list Plugins in your Zowe environment
 is important to make it easy to get the most out of Zowe.
 
 Package management as a concept generally provides a way to find packages such as plugins,
@@ -14,7 +14,7 @@ that using Conda is very similar. But, there are some important abilities that m
 * Very cross platform: Conda is available, and acts very similar on z/OS, Windows, Linux, macOS, and various Unix.
                        Packages can state which platforms they support, so it easy to know what packages you can install.
 * Tagging: On z/OS, Conda packages can contain tagging information, to avoid issues around the difference between EBCDIC & ASCII.
-* Software neutrality: Language-specific package managers are becoming popular, but Conda does not assume the purpose of the package, so you can install most anything.
+* Software neutrality: Language-specific package managers are becoming popular, but Conda does not assume the purpose of the package, so you can install almost anything.
 * Environments: If desired, every user can have a different set of packages, because Conda can install & manage packages in personal folders instead of system ones.
                 A user can even have multiple such environments, and switch between them rapidly to work with different sets of related software without conflict.
 
@@ -22,7 +22,7 @@ that using Conda is very similar. But, there are some important abilities that m
 ## Initial Conda Setup
 
 If you have not installed Conda yet, it can be downloaded as an all-in-one package that has no extra dependencies, known as "miniconda".
-For Linux, Unix, and Windows, this can be downloaded at https://docs.conda.io/en/latest/miniconda.html
+For Linux, Unix, macOS, and Windows, this can be downloaded at https://docs.conda.io/en/latest/miniconda.html
 For z/OS, Conda can be downloaded from Rocket Software at https://www.rocketsoftware.com/zos-open-source
 
 Conda will prompt during the install for certain setup options, 
@@ -50,6 +50,7 @@ Once you have an environment, you should activate it so that the actions you do 
 Conda will detect whether the parameter is a path or a nickname, so this command works for both.
 
 Finally, you can view the Conda environment and other information by checking "info"
+
 `conda info`
 
 ## Managing Conda Channels
@@ -66,18 +67,19 @@ You can have multiple of each, and if a package is present in more than one loca
 
 ## Searching for Packages
 
-Conda has a search utility that checks all the Channels, but it's important to note that because any type of software
-can be installed through Conda, that you probably want to search through the details to help identify which ones are meant for Zowe,
-or use Channels that are distinctly for Zowe so that you can get packages that are strictly for Zowe.
+Conda has a search utility that searches for all Channels,
 
 `conda search anything_you_want`
-`conda search --info this_gives_more_details`
+
+but it's important to note that because any type of software can be installed through Conda, you probably want to search through a detailed view to help identify which ones are meant for Zowe, or use Channels that are distinctly for Zowe so that you can get packages that are strictly for Zowe.
+
+`conda search --info anything_you_want`
 
 ## Using Conda with Zowe
 
 Zowe is not yet available in the form of Conda packages yet, so it must be installed separately.
-If you have Zowe installed on the same system as Conda, some Zowe plugins installed through Conda will automatically register into Zowe.
-In order to do this, the plugins must be able to find Zowe. You should set environment variables before trying to install the plugins:
+If you have Zowe installed on the same system as Conda, some Zowe Plugins installed through Conda will automatically register into Zowe.
+In order to do this, the Plugins must be able to find Zowe. You should set environment variables before trying to install the Plugins:
 
 ### Setting environment variables temporarily:
 z/OS, Linux, Unix:
@@ -105,11 +107,11 @@ Try typing 'environment variable' into the Windows search bar to get to the rele
 ### Installing a Zowe Plugin
 
 A Conda package could contain one or more Zowe Plugins, and a Conda package could contain non-Zowe code alongside Zowe Plugins.
-This is left up to the program vendor, and regardless the install process is the same:
+This is left up to the program vendor and regardless the install process is the same:
 
 `conda install package_name`
 
-If the Zowe environment variables are set, such a package may automatically register plugins into the Zowe instance of your choice.
+If the Zowe environment variables are set, such a package may automatically register Plugins into the Zowe instance of your choice.
 
 ### Zowe Plugin Configuration
 
@@ -119,7 +121,7 @@ Zowe Plugins are intended to be found in a standardized location in the Conda en
 
 `/opt/zowe/plugins`
 
-This folder contains plugins, which in turn contain sub-folders that are the Zowe components that they utilize.
+This folder contains Plugins, which in turn contain sub-folders that are the Zowe components that they utilize.
 If a plugin uses multiple Zowe components, its contents could be found within multiple component folders.
 
 `/opt/zowe/plugins/my_plugin/app-server`

--- a/conda/autoinstall.sh
+++ b/conda/autoinstall.sh
@@ -1,14 +1,5 @@
 #!/bin/sh
 
-# This program and the accompanying materials are
-# made available under the terms of the Eclipse Public License v2.0 which accompanies
-# this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
-# 
-# SPDX-License-Identifier: EPL-2.0
-# 
-# Copyright Contributors to the Zowe Project.
-
-
 if [ -e "${INSTANCE_DIR}/bin/install-app.sh" ]; then
     # TODO reconsider if this is safe or will cause end-user confusion when configuration is required
     ${INSTANCE_DIR}/bin/install-app.sh $APP_PLUGIN_DIR >> $PREFIX/.messages.txt

--- a/conda/autoinstall.sh
+++ b/conda/autoinstall.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 
 if [ -e "${INSTANCE_DIR}/bin/install-app.sh" ]; then
-    # TODO reconsider if this is safe or will cause end-user confusion when configuration is required
     ${INSTANCE_DIR}/bin/install-app.sh $APP_PLUGIN_DIR >> $PREFIX/.messages.txt
 elif [ -e "${ZLUX_ROOT}/zlux-app-server/bin/install-app.sh" ]; then
     if [ -n ${INSTANCE_DIR} ]; then

--- a/conda/autoinstall.sh
+++ b/conda/autoinstall.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+# This program and the accompanying materials are
+# made available under the terms of the Eclipse Public License v2.0 which accompanies
+# this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
+# 
+# SPDX-License-Identifier: EPL-2.0
+# 
+# Copyright Contributors to the Zowe Project.
+
+
+if [ -e "${INSTANCE_DIR}/bin/install-app.sh" ]; then
+    # TODO reconsider if this is safe or will cause end-user confusion when configuration is required
+    ${INSTANCE_DIR}/bin/install-app.sh $APP_PLUGIN_DIR >> $PREFIX/.messages.txt
+elif [ -e "${ZLUX_ROOT}/zlux-app-server/bin/install-app.sh" ]; then
+    if [ -n ${INSTANCE_DIR} ]; then
+        ${ZLUX_ROOT}/zlux-app-server/bin/install-app.sh $APP_PLUGIN_DIR >> $PREFIX/.messages.txt
+    else
+        echo "${PKG_NAME} not registered to Zowe because no instance found. To manually install, run INSTANCE_DIR/bin/install-app.sh $APP_PLUGIN_DIR" >> ${PREFIX}/.messages.txt
+    fi
+fi

--- a/conda/bld.bat
+++ b/conda/bld.bat
@@ -1,8 +1,64 @@
 @echo off
 
-REM /plugins is a primary location for plugins of a component. Secondarily, /components/componentname/plugins
+REM Available env vars:
+REM PREFIX - The location you must copy content to be included into the package
+REM PKG_NAME - The name of your package as seen by a user
+REM PKG_VERSION - The version, as seen by a user
+REM PKG_BUILDNUM - The build number, can be used to distinguish patches by the user
 
-if not exist %PREFIX%\opt\zowe\plugins\app-server\%PKG_NAME% mkdir %PREFIX%\opt\zowe\plugins\app-server\%PKG_NAME%
-robocopy %SRC_DIR% %PREFIX%\opt\zowe\plugins\app-server\%PKG_NAME% * /E > nul
+
+REM /plugins is a primary location for plugins of a component. Secondarily, /components/componentname/plugins
+REM PKG_NAME should be meaningful in the case that multiple plugin dirs (app, cli, apiml) exist within.
+REM If your package includes multiple plugins for a type (such as 2 app framework plugins),
+REM There are different solutions but you may wish to either place common utilities outside the below variables,
+REM While keeping the plugins within these below locations, in a 1-plugin-per-directory scheme
+REM To maintain consistency with other plugins.
+
+set zowe_plugins=%PREFIX%\opt\zowe\plugins
+set app_plugin_dir=%zowe_plugins%\%PKG_NAME%\app-server
+set cli_plugin_dir=%zowe_plugins%\%PKG_NAME%\cli
+set apiml_plugin_dir=%zowe_plugins%\%PKG_NAME%\api-mediation
+REM Special case: zos isnt a component, just a way to make clear what must be put onto zos
+set zos_content_dir=%zowe_plugins%\%PKG_NAME%\zos
+
+REM In the case that the structure of https://github.com/zowe/zowe-install-packaging/issues/1569 is not followed
+REM Then this is assuming it's an app framework plugin.
+if exist %SRC_DIR%\pluginDefinition.json (
+    mkdir %app_plugin_dir%
+    robocopy %SRC_DIR% %app_plugin_dir% * /E > nul
+) else (
+REM Otherwise, if it is following the scheme, here's some hardcoded components that may have content
+    if exist %SRC_DIR%\app-server (
+        mkdir %app_plugin_dir%
+        robocopy %SRC_DIR%\app-server %app_plugin_dir% * /E > nul
+    )
+    if exist %SRC_DIR%\cli (
+        mkdir %cli_plugin_dir%
+        robocopy %SRC_DIR%\cli %cli_plugin_dir% * /E > nul
+    )
+    if exist %SRC_DIR%\api-mediation (
+        mkdir %apiml_plugin_dir%
+        robocopy %SRC_DIR%\api-mediation %apiml_plugin_dir% * /E > nul
+    )
+REM TODO: Is there more to do here for the case of zos content, or is that an install-time concern?
+    if exist %SRC_DIR%\zos (
+        mkdir %zos_content_dir%
+        robocopy %SRC_DIR%\zos %zos_content_dir% * /E > nul
+    )
+)
+
+REM It's fine to copy an entire source directory into $zowe_plugins, but the above is explicit to be educational
+
+REM If present in the same directory as this file, if pre-link, post-link, or pre-unlink .sh or .bat
+REM Files are present, then they will be copied into this package and assist with automation on end user device
+
+REM pre-link---Executed before the package is installed. An error is indicated by a nonzero exit and causes conda to stop and causes the installation to fail.
+REM
+REM post-link---Executed after the package is installed. An error is indicated by a nonzero exist and causes installation to fail. If there is an error, conda does not write any package metadata.
+REM
+REM pre-unlink---Executed before the package is removed. An error is indicated by a nonzero exist and causes the removal to fail.
+REM
+
 
 exit 0
+

--- a/conda/bld.bat
+++ b/conda/bld.bat
@@ -1,11 +1,4 @@
 @echo off
-REM This program and the accompanying materials are
-REM made available under the terms of the Eclipse Public License v2.0 which accompanies
-REM this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
-REM 
-REM SPDX-License-Identifier: EPL-2.0
-REM 
-REM Copyright Contributors to the Zowe Project.
 
 REM /plugins is a primary location for plugins of a component. Secondarily, /components/componentname/plugins
 

--- a/conda/bld.bat
+++ b/conda/bld.bat
@@ -7,12 +7,9 @@ REM SPDX-License-Identifier: EPL-2.0
 REM 
 REM Copyright Contributors to the Zowe Project.
 
+REM /plugins is a primary location for plugins of a component. Secondarily, /components/componentname/plugins
 
-if not exist %PREFIX%\share\zowe\app-server\zlux-app-server\defaults\plugins mkdir %PREFIX%\share\zowe\app-server\zlux-app-server\defaults\plugins
-echo '{"identifier":"%PKG_NAME%","pluginLocation":"%PREFIX%/share/zowe/app-server/plugins/%PKG_NAME%/%PKG_VERSION%"}' ^
-     > %PREFIX%\share\zowe\app-server\zlux-app-server\defaults\plugins\%PKG_NAME%.json
-
-if not exist %PREFIX%\share\zowe\app-server\plugins\%PKG_NAME%\%PKG_VERSION% mkdir %PREFIX%\share\zowe\app-server\plugins\%PKG_NAME%\%PKG_VERSION%
-robocopy %SRC_DIR% %PREFIX%\share\zowe\app-server\plugins\%PKG_NAME%\%PKG_VERSION% * /E > nul
+if not exist %PREFIX%\opt\zowe\plugins\app-server\%PKG_NAME% mkdir %PREFIX%\opt\zowe\plugins\app-server\%PKG_NAME%
+robocopy %SRC_DIR% %PREFIX%\opt\zowe\plugins\app-server\%PKG_NAME% * /E > nul
 
 exit 0

--- a/conda/build.sh
+++ b/conda/build.sh
@@ -8,13 +8,56 @@
 # 
 # Copyright Contributors to the Zowe Project.
 
-mkdir -p $PREFIX/share/zowe/app-server/plugins/$PKG_NAME/$PKG_VERSION
-cp -r ${SRC_DIR}/* $PREFIX/share/zowe/app-server/plugins/$PKG_NAME/$PKG_VERSION
-mkdir -p $PREFIX/share/zowe/app-server/zlux-app-server/defaults/plugins
-echo "{\"identifier\":\"${PKG_NAME}\",\"pluginLocation\":\"${PREFIX}/share/zowe/app-server/plugins/${PKG_NAME}/${PKG_VERSION}\"}" \
-     > $PREFIX/share/zowe/app-server/zlux-app-server/defaults/plugins/${PKG_NAME}.json
+# /plugins is a primary location for plugins of a component. Secondarily, /components/componentname/plugins
 
-cd $PREFIX/share/zowe/app-server/plugins/$PKG_NAME/$PKG_VERSION
+destination=$PREFIX/opt/zowe/plugins/app-server/$PKG_NAME
+mkdir -p $destination
+cp -r ${SRC_DIR}/* $destination
+cd $destination
 rm -f build_env_setup.sh conda_build.sh metadata_conda_debug.yaml *.ppf
+
+#mkdir -p "${PREFIX}/etc/conda/activate.d"
+#mkdir -p "${PREFIX}/etc/conda/deactivate.d"
+#cp "${RECIPE_DIR}/activate.sh" "${PREFIX}/etc/conda/activate.d/${PKG_NAME}_activate.sh"
+#cp "${RECIPE_DIR}/activate.bat" "${PREFIX}/etc/conda/activate.d/${PKG_NAME}_activate.bat"
+#cp "${RECIPE_DIR}/deactivate.sh" "${PREFIX}/etc/conda/deactivate.d/${PKG_NAME}_deactivate.sh"
+#cp "${RECIPE_DIR}/deactivate.bat" "${PREFIX}/etc/conda/deactivate.d/${PKG_NAME}_deactivate.bat"
+
+#mkdir -p "${PREFIX}/bin"
+#cp "${RECIPE_DIR}/post-link.sh" "${PREFIX}/bin/.${PKG_NAME}-post-link.sh"
+#cp "${RECIPE_DIR}/pre-unlink.sh" "${PREFIX}/bin/.${PKG_NAME}-pre-unlink.sh"
+
+#
+#for CHANGE in "activate" "deactivate"
+#do
+#    mkdir -p "${PREFIX}/etc/conda/${CHANGE}.d"
+#    cp "${RECIPE_DIR}/${CHANGE}.sh" "${PREFIX}/etc/conda/${CHANGE}.d/${PKG_NAME}_${CHANGE}.sh"
+#done
+#
+#
+# bin/.<name>-<action>.sh
+# bin/.org.zowe.blah-pre-link.sh
+#
+#
+# pre-link---Executed before the package is installed. An error is indicated by a nonzero exit and causes conda to stop and causes the installation to fail.
+#
+# post-link---Executed after the package is installed. An error is indicated by a nonzero exist and causes installation to fail. If there is an error, conda does not write any package metadata.
+#
+# pre-unlink---Executed before the package is removed. An error is indicated by a nonzero exist and causes the removal to fail.
+#
+# PREFIX
+# The install prefix.
+# PKG_NAME
+#
+#
+# The name of the package.
+# PKG_VERSION
+# The version of the package.
+#
+# PKG_BUILDNUM
+# The build number of the package.
+#
+
+
 
 exit 0

--- a/conda/build.sh
+++ b/conda/build.sh
@@ -8,56 +8,63 @@
 # 
 # Copyright Contributors to the Zowe Project.
 
+# Available env vars:
+# PREFIX - The location you must copy content to be included into the package
+# PKG_NAME - The name of your package as seen by a user
+# PKG_VERSION - The version, as seen by a user
+# PKG_BUILDNUM - The build number, can be used to distinguish patches by the user
+
+
 # /plugins is a primary location for plugins of a component. Secondarily, /components/componentname/plugins
+# PKG_NAME should be meaningful in the case that multiple plugin dirs (app, cli, apiml) exist within.
+zowe_plugins=$PREFIX/opt/zowe/plugins
+app_plugin_dir=$zowe_plugins/app-server/$PKG_NAME
+cli_plugin_dir=$zowe_plugins/cli/$PKG_NAME
+apiml_plugin_dir=$zowe_plugins/api-mediation/$PKG_NAME
+# Special case: zos isnt a component, just a way to make clear what must be put onto zos
+zos_content_dir=$zowe_plugins/zos/$PKG_NAME
 
-destination=$PREFIX/opt/zowe/plugins/app-server/$PKG_NAME
-mkdir -p $destination
-cp -r ${SRC_DIR}/* $destination
-cd $destination
-rm -f build_env_setup.sh conda_build.sh metadata_conda_debug.yaml *.ppf
+# In the case that the structure of https://github.com/zowe/zowe-install-packaging/issues/1569 is not followed
+# Then this is assuming it's an app framework plugin.
+if [ -e "${SRC_DIR}/pluginDefinition.json" ]
+then
+    mkdir -p $app_dir
+    cp -r ${SRC_DIR}/* $app_dir
+    cd $app_dir
+    rm -f build_env_setup.sh conda_build.sh metadata_conda_debug.yaml *.ppf
 
-#mkdir -p "${PREFIX}/etc/conda/activate.d"
-#mkdir -p "${PREFIX}/etc/conda/deactivate.d"
-#cp "${RECIPE_DIR}/activate.sh" "${PREFIX}/etc/conda/activate.d/${PKG_NAME}_activate.sh"
-#cp "${RECIPE_DIR}/activate.bat" "${PREFIX}/etc/conda/activate.d/${PKG_NAME}_activate.bat"
-#cp "${RECIPE_DIR}/deactivate.sh" "${PREFIX}/etc/conda/deactivate.d/${PKG_NAME}_deactivate.sh"
-#cp "${RECIPE_DIR}/deactivate.bat" "${PREFIX}/etc/conda/deactivate.d/${PKG_NAME}_deactivate.bat"
+# Otherwise, if it is following the scheme, here's some hardcoded components that may have content
+else
+    if [ -d "${SRC_DIR}/app-server" ]; then
+        mkdir -p $app_plugin_dir
+        cp -r ${SRC_DIR}/app-server/* $app_plugin_dir
+        cd $app_plugin_dir
+        rm -f build_env_setup.sh conda_build.sh metadata_conda_debug.yaml *.ppf
+    fi
+    if [ -d "${SRC_DIR}/cli" ]; then
+        mkdir -p $cli_plugin_dir
+        cp -r ${SRC_DIR}/cli/* $cli_plugin_dir
+    fi
+    if [ -d "${SRC_DIR}/api-mediation" ]; then
+        mkdir -p $apiml_plugin_dir
+        cp -r ${SRC_DIR}/api-mediation/* $apiml_plugin_dir
+    fi
+# TODO: Is there more to do here for the case of zos content, or is that an install-time concern?
+    if [ -d "${SRC_DIR}/zos" ]; then
+        mkdir -p $zos_content_dir
+        cp -r ${SRC_DIR}/zos/* $zos_content_dir
+    fi
+fi
 
-#mkdir -p "${PREFIX}/bin"
-#cp "${RECIPE_DIR}/post-link.sh" "${PREFIX}/bin/.${PKG_NAME}-post-link.sh"
-#cp "${RECIPE_DIR}/pre-unlink.sh" "${PREFIX}/bin/.${PKG_NAME}-pre-unlink.sh"
+# If present in the same directory as this file, if pre-link, post-link, or pre-unlink .sh or .bat
+# Files are present, then they will be copied into this package and assist with automation on end user device
 
-#
-#for CHANGE in "activate" "deactivate"
-#do
-#    mkdir -p "${PREFIX}/etc/conda/${CHANGE}.d"
-#    cp "${RECIPE_DIR}/${CHANGE}.sh" "${PREFIX}/etc/conda/${CHANGE}.d/${PKG_NAME}_${CHANGE}.sh"
-#done
-#
-#
-# bin/.<name>-<action>.sh
-# bin/.org.zowe.blah-pre-link.sh
-#
-#
 # pre-link---Executed before the package is installed. An error is indicated by a nonzero exit and causes conda to stop and causes the installation to fail.
 #
 # post-link---Executed after the package is installed. An error is indicated by a nonzero exist and causes installation to fail. If there is an error, conda does not write any package metadata.
 #
 # pre-unlink---Executed before the package is removed. An error is indicated by a nonzero exist and causes the removal to fail.
 #
-# PREFIX
-# The install prefix.
-# PKG_NAME
-#
-#
-# The name of the package.
-# PKG_VERSION
-# The version of the package.
-#
-# PKG_BUILDNUM
-# The build number of the package.
-#
-
 
 
 exit 0

--- a/conda/build.sh
+++ b/conda/build.sh
@@ -1,13 +1,5 @@
 #!/bin/sh
 
-# This program and the accompanying materials are
-# made available under the terms of the Eclipse Public License v2.0 which accompanies
-# this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
-# 
-# SPDX-License-Identifier: EPL-2.0
-# 
-# Copyright Contributors to the Zowe Project.
-
 # Available env vars:
 # PREFIX - The location you must copy content to be included into the package
 # PKG_NAME - The name of your package as seen by a user

--- a/conda/build.sh
+++ b/conda/build.sh
@@ -9,6 +9,11 @@
 
 # /plugins is a primary location for plugins of a component. Secondarily, /components/componentname/plugins
 # PKG_NAME should be meaningful in the case that multiple plugin dirs (app, cli, apiml) exist within.
+# If your package includes multiple plugins for a type (such as 2 app framework plugins),
+# There are different solutions but you may wish to either place common utilities outside the below variables,
+# While keeping the plugins within these below locations, in a 1-plugin-per-directory scheme
+# To maintain consistency with other plugins.
+
 zowe_plugins=$PREFIX/opt/zowe/plugins
 app_plugin_dir=$zowe_plugins/app-server/$PKG_NAME
 cli_plugin_dir=$zowe_plugins/cli/$PKG_NAME
@@ -20,9 +25,9 @@ zos_content_dir=$zowe_plugins/zos/$PKG_NAME
 # Then this is assuming it's an app framework plugin.
 if [ -e "${SRC_DIR}/pluginDefinition.json" ]
 then
-    mkdir -p $app_dir
-    cp -r ${SRC_DIR}/* $app_dir
-    cd $app_dir
+    mkdir -p $app_plugin_dir
+    cp -r ${SRC_DIR}/* $app_plugin_dir
+    cd $app_plugin_dir
     rm -f build_env_setup.sh conda_build.sh metadata_conda_debug.yaml *.ppf
 
 # Otherwise, if it is following the scheme, here's some hardcoded components that may have content

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,14 +1,5 @@
 {% set data = load_setup_py_data(setup_file='./setup.py', from_recipe_dir=True) %}
 
-# This program and the accompanying materials are
-# made available under the terms of the Eclipse Public License v2.0 which accompanies
-# this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
-# 
-# SPDX-License-Identifier: EPL-2.0
-# 
-# Copyright Contributors to the Zowe Project.
-
-
 # This example is opinionated toward getting metata from an app framework plugin
 # That is not required, and you can write your own meta.yaml instead.
 # But for consistency if your package is for multiple zowe components

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -26,6 +26,6 @@ build:
 about:
   home: "{{ data.get('homepage') }}"
   license: "{{ data.get('license') }}"
-  license_file: "LICENSE"
+#  license_file: "LICENSE"
   summary: "{{ data.get('description') }}"
   doc_url: "https://docs.zowe.org"

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,10 +1,10 @@
 {% set data = load_setup_py_data(setup_file='./setup.py', from_recipe_dir=True) %}
 
-# This example is opinionated toward getting metata from an app framework plugin
-# That is not required, and you can write your own meta.yaml instead.
+# This example is opinionated toward getting metadata from an app framework plugin
+# that is not required, and you can write your own meta.yaml instead.
 # But for consistency if your package is for multiple zowe components
-# You should ensure that all metadata for the different components is related
-# So that end users can see the relationship.
+# you should ensure that all metadata for the different components is related
+# so that end users can see the relationship.
 
 package:
   name: "{{ data.get('name')|lower }}"

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -8,6 +8,13 @@
 # 
 # Copyright Contributors to the Zowe Project.
 
+
+# This example is opinionated toward getting metata from an app framework plugin
+# That is not required, and you can write your own meta.yaml instead.
+# But for consistency if your package is for multiple zowe components
+# You should ensure that all metadata for the different components is related
+# So that end users can see the relationship.
+
 package:
   name: "{{ data.get('name')|lower }}"
   version: "{{ data.get('version') }}"

--- a/conda/post-link.sh
+++ b/conda/post-link.sh
@@ -48,21 +48,22 @@ echo "Finding instance... ZOWE_INST=${ZOWE_INST}, ZOWE_INSTANCE_DIR=${ZOWE_INSTA
 
 # Relevant environment variables hopefully exist by this time.
 # Here we determing if any automatic actions can be taken, based on what the package contains.
-
-if [ -e "$PREFIX/opt/zowe/plugins/app-server/$PKG_NAME/autoinstall.sh" ]; then
+if [ -e "$PREFIX/opt/zowe/plugins/$PKG_NAME/app-server/autoinstall.sh" ]; then
     #autoinstall script exists, try it.
     #Map environment variables in a way that is package manager neutral, in case scripts are reused outside of conda
-    INSTANCE_DIR=$ZOWE_INST ZLUX_ROOT=$ZLUX_ROOT APP_PLUGIN_DIR=$PREFIX/opt/zowe/plugins/app-server/$PKG_NAME $PREFIX/opt/zowe/plugins/app-server/$PKG_NAME/autoinstall.sh
-elif [ -d "$PREFIX/opt/zowe/plugins/app-server/$PKG_NAME" ]; then
+    INSTANCE_DIR=$ZOWE_INST ZLUX_ROOT=$ZLUX_ROOT APP_PLUGIN_DIR=$PREFIX/opt/zowe/plugins/$PKG_NAME/app-server $PREFIX/opt/zowe/plugins/$PKG_NAME/app-server/autoinstall.sh
+elif [ -d "$PREFIX/opt/zowe/plugins/$PKG_NAME/app-server" ]; then
     if [ -e "${ZOWE_INST}/bin/install-app.sh" ]; then
         # TODO reconsider if this is safe or will cause end-user confusion when configuration is required
-        ${ZOWE_INST}/bin/install-app.sh $PREFIX/opt/zowe/plugins/app-server/$PKG_NAME >> $PREFIX/.messages.txt
+        ${ZOWE_INST}/bin/install-app.sh $PREFIX/opt/zowe/plugins/$PKG_NAME/app-server >> $PREFIX/.messages.txt
     elif [ -e "${ZLUX_ROOT}/zlux-app-server/bin/install-app.sh" ]; then
         if [ -n ${ZOWE_INST} ]; then
-            ${ZLUX_ROOT}/zlux-app-server/bin/install-app.sh $PREFIX/opt/zowe/plugins/app-server/$PKG_NAME >> $PREFIX/.messages.txt
+            ${ZLUX_ROOT}/zlux-app-server/bin/install-app.sh $PREFIX/opt/zowe/plugins/$PKG_NAME/app-server >> $PREFIX/.messages.txt
         else
-            echo "${PKG_NAME} not registered to Zowe because no instance found. To manually install, run INSTANCE_DIR/bin/install-app.sh $PREFIX/opt/zowe/plugins/app-server/$PKG_NAME" >> ${PREFIX}/.messages.txt
+            echo "${PKG_NAME} not registered to Zowe because no instance found. To manually install, run INSTANCE_DIR/bin/install-app.sh $PREFIX/opt/zowe/plugins/$PKG_NAME/app-server" >> ${PREFIX}/.messages.txt
         fi
+    else
+        echo "${PKG_NAME} not registered to Zowe because no instance found. To manually install, run INSTANCE_DIR/bin/install-app.sh $PREFIX/opt/zowe/plugins/$PKG_NAME/app-server" >> ${PREFIX}/.messages.txt
     fi
 fi
 

--- a/conda/post-link.sh
+++ b/conda/post-link.sh
@@ -46,6 +46,9 @@ fi
 echo "Finding instance... ZOWE_INST=${ZOWE_INST}, ZOWE_INSTANCE_DIR=${ZOWE_INSTANCE_DIR}, INSTANCE_DIR=${INSTANCE_DIR}, ZOWE_WORKSPACE_DIR=${ZOWE_WORKSPACE_DIR}, WORKSPACE_DIR=${WORKSPACE_DIR}" >> $PREFIX/.messages.txt
 
 
+# TODO this section only handles app-server plugins. Consult the api-mediation and cli Zowe community and
+# Documentation to learn what should be done for those types of plugins
+
 # Relevant environment variables hopefully exist by this time.
 # Here we determing if any automatic actions can be taken, based on what the package contains.
 if [ -e "$PREFIX/opt/zowe/plugins/$PKG_NAME/app-server/autoinstall.sh" ]; then

--- a/conda/post-link.sh
+++ b/conda/post-link.sh
@@ -76,3 +76,4 @@ fi
 
 # Here: plugins for other components can potentially be auto-installed
 
+# TODO: Print a warning if zos folder seen but not running on zos

--- a/conda/post-link.sh
+++ b/conda/post-link.sh
@@ -1,13 +1,5 @@
 #!/bin/sh
 
-# This program and the accompanying materials are
-# made available under the terms of the Eclipse Public License v2.0 which accompanies
-# this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
-# 
-# SPDX-License-Identifier: EPL-2.0
-# 
-# Copyright Contributors to the Zowe Project.
-
 echo "Initializing for Zowe install" > $PREFIX/.messages.txt
 
 # Before attempting install of plugin into Zowe, must first gather relevant environment variables

--- a/conda/post-link.sh
+++ b/conda/post-link.sh
@@ -8,24 +8,21 @@
 # 
 # Copyright Contributors to the Zowe Project.
 
-echo "Starting zowe install" > $PREFIX/.messages.txt
+echo "Initializing for Zowe install" > $PREFIX/.messages.txt
 
-if [ -n "$ZOWE_ROOT_DIR" ]
-then
-  if [ -d "${ZOWE_ROOT_DIR}/components/app-server" ]
-  then
+# Before attempting install of plugin into Zowe, must first gather relevant environment variables
+# This is not guaranteed, and will fail if the user has not previously specified the location of Zowe
+
+if [ -n "$ZOWE_ROOT_DIR" ]; then
+  if [ -d "${ZOWE_ROOT_DIR}/components/app-server" ]; then
       ZLUX_ROOT=$ZOWE_ROOT_DIR/components/app-server/share
-  elif [ -d "${ZOWE_ROOT_DIR}/zlux-app-server" ]
-  then
+  elif [ -d "${ZOWE_ROOT_DIR}/zlux-app-server" ]; then
       ZLUX_ROOT=$ZOWE_ROOT_DIR
   fi
-elif [ -n "$ROOT_DIR" ]
-then
-  if [ -d "${ROOT_DIR}/components/app-server" ]
-  then
+elif [ -n "$ROOT_DIR" ]; then
+  if [ -d "${ROOT_DIR}/components/app-server" ]; then
     ZLUX_ROOT=$ROOT_DIR/components/app-server/share
-  elif [ -d "${ROOT_DIR}/zlux-app-server" ]
-  then
+  elif [ -d "${ROOT_DIR}/zlux-app-server" ]; then
     ZLUX_ROOT=$ROOT_DIR  
   fi
 fi
@@ -33,44 +30,49 @@ fi
 echo "Finding root... ZLUX_ROOT=${ZLUX_ROOT}, ZOWE_ROOT_DIR=${ZOWE_ROOT_DIR}, ROOT_DIR=${ROOT_DIR}" >> $PREFIX/.messages.txt
 
 
-if [ -e "${ZOWE_WORKSPACE_DIR}/../bin/install-app.sh" ]
-then
+if [ -e "${ZOWE_WORKSPACE_DIR}/../bin/install-app.sh" ]; then
   ZOWE_INST=${ZOWE_WORKSPACE_DIR}/../
-elif [ -d "${ZOWE_WORKSPACE_DIR}/app-server" ]
-then
+elif [ -d "${ZOWE_WORKSPACE_DIR}/app-server" ]; then
   ZOWE_INST=${ZOWE_WORKSPACE_DIR}/../
-elif [ -e "${ZOWE_INSTANCE_DIR}/bin/install-app.sh" ]
-then
+elif [ -e "${ZOWE_INSTANCE_DIR}/bin/install-app.sh" ]; then
   ZOWE_INST=${ZOWE_INSTANCE_DIR}
-elif [ -d "${ZOWE_INSTANCE_DIR}/workspace/app-server" ]
-then
+elif [ -d "${ZOWE_INSTANCE_DIR}/workspace/app-server" ]; then
   ZOWE_INST=${ZOWE_INSTANCE_DIR}
-elif [ -e "${WORKSPACE_DIR}/../bin/install-app.sh" ]
-then
+elif [ -e "${WORKSPACE_DIR}/../bin/install-app.sh" ]; then
   ZOWE_INST=${WORKSPACE_DIR}/../
-elif [ -d "${WORKSPACE_DIR}/app-server" ]
-then
+elif [ -d "${WORKSPACE_DIR}/app-server" ]; then
   ZOWE_INST=${WORKSPACE_DIR}/../
-elif [ -e "${INSTANCE_DIR}/bin/install-app.sh" ]
-then
+elif [ -e "${INSTANCE_DIR}/bin/install-app.sh" ]; then
   ZOWE_INST=${INSTANCE_DIR}
-elif [ -d "${INSTANCE_DIR}/workspace/app-server" ]
-then
-  ZOWE_INST=${INSTANCE_DIR}
+elif [ -d "${INSTANCE_DIR}/workspace/app-server" ]; then
+    ZOWE_INST=${INSTANCE_DIR}
+elif [ -d "${HOME}/.zowe/workspace/app-server" ]; then
+    echo "Warning: Using fallback default location for zowe instance of ~/.zowe" >> $PREFIX/.messages.txt
+    ZOWE_INST=${HOME}/.zowe
 fi
 
 echo "Finding instance... ZOWE_INST=${ZOWE_INST}, ZOWE_INSTANCE_DIR=${ZOWE_INSTANCE_DIR}, INSTANCE_DIR=${INSTANCE_DIR}, ZOWE_WORKSPACE_DIR=${ZOWE_WORKSPACE_DIR}, WORKSPACE_DIR=${WORKSPACE_DIR}" >> $PREFIX/.messages.txt
 
-if [ -e "${ZOWE_INST}/bin/install-app.sh" ]
-then
-    ${ZOWE_INST}/bin/install-app.sh $PREFIX/opt/zowe/plugins/app-server/$PKG_NAME >> $PREFIX/.messages.txt
-elif [ -e "${ZLUX_ROOT}/zlux-app-server/bin/install-app.sh" ]
-then
-    if [ -n ${ZOWE_INST} ]
-    then
-        ${ZLUX_ROOT}/zlux-app-server/bin/install-app.sh $PREFIX/opt/zowe/plugins/app-server/$PKG_NAME >> $PREFIX/.messages.txt
-    else
-        echo "${PKG_NAME} not registered to Zowe because no instance found. To manually install, run INSTANCE_DIR/bin/install-app.sh $PREFIX/opt/zowe/plugins/app-server/$PKG_NAME" >> ${PREFIX}/.messages.txt
+
+# Relevant environment variables hopefully exist by this time.
+# Here we determing if any automatic actions can be taken, based on what the package contains.
+
+if [ -e "$PREFIX/opt/zowe/plugins/app-server/$PKG_NAME/autoinstall.sh" ]; then
+    #autoinstall script exists, try it.
+    #Map environment variables in a way that is package manager neutral, in case scripts are reused outside of conda
+    INSTANCE_DIR=$ZOWE_INST ZLUX_ROOT=$ZLUX_ROOT APP_PLUGIN_DIR=$PREFIX/opt/zowe/plugins/app-server/$PKG_NAME $PREFIX/opt/zowe/plugins/app-server/$PKG_NAME/autoinstall.sh
+elif [ -d "$PREFIX/opt/zowe/plugins/app-server/$PKG_NAME" ]; then
+    if [ -e "${ZOWE_INST}/bin/install-app.sh" ]; then
+        # TODO reconsider if this is safe or will cause end-user confusion when configuration is required
+        ${ZOWE_INST}/bin/install-app.sh $PREFIX/opt/zowe/plugins/app-server/$PKG_NAME >> $PREFIX/.messages.txt
+    elif [ -e "${ZLUX_ROOT}/zlux-app-server/bin/install-app.sh" ]; then
+        if [ -n ${ZOWE_INST} ]; then
+            ${ZLUX_ROOT}/zlux-app-server/bin/install-app.sh $PREFIX/opt/zowe/plugins/app-server/$PKG_NAME >> $PREFIX/.messages.txt
+        else
+            echo "${PKG_NAME} not registered to Zowe because no instance found. To manually install, run INSTANCE_DIR/bin/install-app.sh $PREFIX/opt/zowe/plugins/app-server/$PKG_NAME" >> ${PREFIX}/.messages.txt
+        fi
     fi
 fi
+
+# Here: plugins for other components can potentially be auto-installed
 

--- a/conda/post-link.sh
+++ b/conda/post-link.sh
@@ -1,0 +1,76 @@
+#!/bin/sh
+
+# This program and the accompanying materials are
+# made available under the terms of the Eclipse Public License v2.0 which accompanies
+# this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
+# 
+# SPDX-License-Identifier: EPL-2.0
+# 
+# Copyright Contributors to the Zowe Project.
+
+echo "Starting zowe install" > $PREFIX/.messages.txt
+
+if [ -n "$ZOWE_ROOT_DIR" ]
+then
+  if [ -d "${ZOWE_ROOT_DIR}/components/app-server" ]
+  then
+      ZLUX_ROOT=$ZOWE_ROOT_DIR/components/app-server/share
+  elif [ -d "${ZOWE_ROOT_DIR}/zlux-app-server" ]
+  then
+      ZLUX_ROOT=$ZOWE_ROOT_DIR
+  fi
+elif [ -n "$ROOT_DIR" ]
+then
+  if [ -d "${ROOT_DIR}/components/app-server" ]
+  then
+    ZLUX_ROOT=$ROOT_DIR/components/app-server/share
+  elif [ -d "${ROOT_DIR}/zlux-app-server" ]
+  then
+    ZLUX_ROOT=$ROOT_DIR  
+  fi
+fi
+
+echo "Finding root... ZLUX_ROOT=${ZLUX_ROOT}, ZOWE_ROOT_DIR=${ZOWE_ROOT_DIR}, ROOT_DIR=${ROOT_DIR}" >> $PREFIX/.messages.txt
+
+
+if [ -e "${ZOWE_WORKSPACE_DIR}/../bin/install-app.sh" ]
+then
+  ZOWE_INST=${ZOWE_WORKSPACE_DIR}/../
+elif [ -d "${ZOWE_WORKSPACE_DIR}/app-server" ]
+then
+  ZOWE_INST=${ZOWE_WORKSPACE_DIR}/../
+elif [ -e "${ZOWE_INSTANCE_DIR}/bin/install-app.sh" ]
+then
+  ZOWE_INST=${ZOWE_INSTANCE_DIR}
+elif [ -d "${ZOWE_INSTANCE_DIR}/workspace/app-server" ]
+then
+  ZOWE_INST=${ZOWE_INSTANCE_DIR}
+elif [ -e "${WORKSPACE_DIR}/../bin/install-app.sh" ]
+then
+  ZOWE_INST=${WORKSPACE_DIR}/../
+elif [ -d "${WORKSPACE_DIR}/app-server" ]
+then
+  ZOWE_INST=${WORKSPACE_DIR}/../
+elif [ -e "${INSTANCE_DIR}/bin/install-app.sh" ]
+then
+  ZOWE_INST=${INSTANCE_DIR}
+elif [ -d "${INSTANCE_DIR}/workspace/app-server" ]
+then
+  ZOWE_INST=${INSTANCE_DIR}
+fi
+
+echo "Finding instance... ZOWE_INST=${ZOWE_INST}, ZOWE_INSTANCE_DIR=${ZOWE_INSTANCE_DIR}, INSTANCE_DIR=${INSTANCE_DIR}, ZOWE_WORKSPACE_DIR=${ZOWE_WORKSPACE_DIR}, WORKSPACE_DIR=${WORKSPACE_DIR}" >> $PREFIX/.messages.txt
+
+if [ -e "${ZOWE_INST}/bin/install-app.sh" ]
+then
+    ${ZOWE_INST}/bin/install-app.sh $PREFIX/opt/zowe/plugins/app-server/$PKG_NAME >> $PREFIX/.messages.txt
+elif [ -e "${ZLUX_ROOT}/zlux-app-server/bin/install-app.sh" ]
+then
+    if [ -n ${ZOWE_INST} ]
+    then
+        ${ZLUX_ROOT}/zlux-app-server/bin/install-app.sh $PREFIX/opt/zowe/plugins/app-server/$PKG_NAME >> $PREFIX/.messages.txt
+    else
+        echo "${PKG_NAME} not registered to Zowe because no instance found. To manually install, run INSTANCE_DIR/bin/install-app.sh $PREFIX/opt/zowe/plugins/app-server/$PKG_NAME" >> ${PREFIX}/.messages.txt
+    fi
+fi
+

--- a/conda/pre-unlink.sh
+++ b/conda/pre-unlink.sh
@@ -20,6 +20,9 @@ else
   NODE_BIN=node
 fi
 
+# TODO this section only handles app-server plugins. Consult the api-mediation and cli Zowe community and
+# Documentation to learn what should be done for those types of plugins
+
 package_location=$PREFIX/opt/zowe/plugins/$PKG_NAME/app-server
 json_location=${ZOWE_INST}/workspace/app-server/plugins/${PKG_NAME}.json
 

--- a/conda/pre-unlink.sh
+++ b/conda/pre-unlink.sh
@@ -1,13 +1,5 @@
 #!/bin/sh
 
-# This program and the accompanying materials are
-# made available under the terms of the Eclipse Public License v2.0 which accompanies
-# this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
-# 
-# SPDX-License-Identifier: EPL-2.0
-# 
-# Copyright Contributors to the Zowe Project.
-
 if [ -d "${ZOWE_WORKSPACE_DIR}/app-server/ZLUX" ]; then
   ZOWE_INST=${ZOWE_WORKSPACE_DIR}/../
 elif [ -e "${ZOWE_INSTANCE_DIR}/workspace/app-server/ZLUX" ]; then
@@ -18,7 +10,18 @@ elif [ -e "${INSTANCE_DIR}/workspace/app-server/ZLUX" ]; then
   ZOWE_INST=${INSTANCE_DIR}
 fi
 
-if [ -e "${ZOWE_INST}/workspace/app-server/plugins/${PKG_NAME}.json" ]; then
-  location=$PREFIX/opt/zowe/plugins/app-server/$PKG_NAME node -e "const fs=require('fs'); const content=require('${ZOWE_INST}/workspace/app-server/plugins/${PKG_NAME}.json'); if (content.pluginLocation == '${location}') { fs.unlinkSync('${ZOWE_INST}/workspace/app-server/plugins/${PKG_NAME}.json'); }" > $PREFIX/.messages.txt
+if [ -n "$NODE_HOME" ]
+then
+  NODE_BIN=${NODE_HOME}/bin/node
+else
+  NODE_BIN=node
+fi
+
+package_location=$PREFIX/opt/zowe/plugins/app-server/$PKG_NAME
+json_location=${ZOWE_INST}/workspace/app-server/plugins/${PKG_NAME}.json
+
+if [ -e "${json_location}" ]; then
+  _BPXK_AUTOCVT=ON _TAG_REDIR_ERR=txt _TAG_REDIR_IN=txt _TAG_REDIR_OUT=txt __UNTAGGED_READ_MODE=V6 \
+  ${NODE_BIN} -e "const fs=require('fs'); const content=require('${json_location}'); if (content.pluginLocation == '${package_location}') { fs.unlinkSync('${json_location}'); }" > $PREFIX/.messages.txt
 fi
 

--- a/conda/pre-unlink.sh
+++ b/conda/pre-unlink.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+# This program and the accompanying materials are
+# made available under the terms of the Eclipse Public License v2.0 which accompanies
+# this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
+# 
+# SPDX-License-Identifier: EPL-2.0
+# 
+# Copyright Contributors to the Zowe Project.
+
+if [ -d "${ZOWE_WORKSPACE_DIR}/app-server/ZLUX" ]
+then
+  ZOWE_INST=${ZOWE_WORKSPACE_DIR}/../
+elif [ -e "${ZOWE_INSTANCE_DIR}/workspace/app-server/ZLUX" ]
+then
+  ZOWE_INST=${ZOWE_INSTANCE_DIR}
+elif [ -e "${WORKSPACE_DIR}/app-server/ZLUX" ]
+then
+  ZOWE_INST=${WORKSPACE_DIR}/../
+elif [ -e "${INSTANCE_DIR}/workspace/app-server/ZLUX" ]
+then
+  ZOWE_INST=${INSTANCE_DIR}
+fi
+
+if [ -e "${ZOWE_INST}/workspace/app-server/plugins/${PKG_NAME}.json" ]
+then
+  location=$PREFIX/opt/zowe/plugins/app-server/$PKG_NAME node -e "const fs=require('fs'); const content=require('${ZOWE_INST}/workspace/app-server/plugins/${PKG_NAME}.json'); if (content.pluginLocation == '${location}') { fs.unlinkSync('${ZOWE_INST}/workspace/app-server/plugins/${PKG_NAME}.json'); }" > $PREFIX/.messages.txt
+fi
+

--- a/conda/pre-unlink.sh
+++ b/conda/pre-unlink.sh
@@ -8,22 +8,17 @@
 # 
 # Copyright Contributors to the Zowe Project.
 
-if [ -d "${ZOWE_WORKSPACE_DIR}/app-server/ZLUX" ]
-then
+if [ -d "${ZOWE_WORKSPACE_DIR}/app-server/ZLUX" ]; then
   ZOWE_INST=${ZOWE_WORKSPACE_DIR}/../
-elif [ -e "${ZOWE_INSTANCE_DIR}/workspace/app-server/ZLUX" ]
-then
+elif [ -e "${ZOWE_INSTANCE_DIR}/workspace/app-server/ZLUX" ]; then
   ZOWE_INST=${ZOWE_INSTANCE_DIR}
-elif [ -e "${WORKSPACE_DIR}/app-server/ZLUX" ]
-then
+elif [ -e "${WORKSPACE_DIR}/app-server/ZLUX" ]; then
   ZOWE_INST=${WORKSPACE_DIR}/../
-elif [ -e "${INSTANCE_DIR}/workspace/app-server/ZLUX" ]
-then
+elif [ -e "${INSTANCE_DIR}/workspace/app-server/ZLUX" ]; then
   ZOWE_INST=${INSTANCE_DIR}
 fi
 
-if [ -e "${ZOWE_INST}/workspace/app-server/plugins/${PKG_NAME}.json" ]
-then
+if [ -e "${ZOWE_INST}/workspace/app-server/plugins/${PKG_NAME}.json" ]; then
   location=$PREFIX/opt/zowe/plugins/app-server/$PKG_NAME node -e "const fs=require('fs'); const content=require('${ZOWE_INST}/workspace/app-server/plugins/${PKG_NAME}.json'); if (content.pluginLocation == '${location}') { fs.unlinkSync('${ZOWE_INST}/workspace/app-server/plugins/${PKG_NAME}.json'); }" > $PREFIX/.messages.txt
 fi
 

--- a/conda/pre-unlink.sh
+++ b/conda/pre-unlink.sh
@@ -8,6 +8,9 @@ elif [ -e "${WORKSPACE_DIR}/app-server/ZLUX" ]; then
   ZOWE_INST=${WORKSPACE_DIR}/../
 elif [ -e "${INSTANCE_DIR}/workspace/app-server/ZLUX" ]; then
   ZOWE_INST=${INSTANCE_DIR}
+elif [ -d "${HOME}/.zowe/workspace/app-server" ]; then
+    echo "Warning: Using fallback default location for zowe instance of ~/.zowe" >> $PREFIX/.messages.txt
+    ZOWE_INST=${HOME}/.zowe
 fi
 
 if [ -n "$NODE_HOME" ]
@@ -17,7 +20,7 @@ else
   NODE_BIN=node
 fi
 
-package_location=$PREFIX/opt/zowe/plugins/app-server/$PKG_NAME
+package_location=$PREFIX/opt/zowe/plugins/$PKG_NAME/app-server
 json_location=${ZOWE_INST}/workspace/app-server/plugins/${PKG_NAME}.json
 
 if [ -e "${json_location}" ]; then

--- a/conda/setup.py
+++ b/conda/setup.py
@@ -3,13 +3,6 @@ import json
 import os
 import sys
 import glob
-# This program and the accompanying materials are
-# made available under the terms of the Eclipse Public License v2.0 which accompanies
-# this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
-# 
-# SPDX-License-Identifier: EPL-2.0
-# 
-# Copyright Contributors to the Zowe Project.
 
 print('Loading package attributes from pluginDefinition.json')
 with open('./plugin/pluginDefinition.json', 'r') as f:


### PR DESCRIPTION
According to the multi-component packaging scheme being discussed in https://github.com/zowe/zowe-install-packaging/issues/1569 I have reworked previous conda code to utilize the new structure, plus, I have found a way to make it so that conda can install zowe plugins directly into zowe under some circumstances. Work for plugins other than for the app framework (such as cli and apiml services) still need good examples, but otherwise the readme and scripts serve as examples for those who wish to also use conda for delivering zowe plugins.