### PR TITLE
Add manifest when building containers

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,8 +5,6 @@ name: app-server build
 on:
   push:
     branches: [ master ]
-  pull_request:
-    branches: [ staging ]
   workflow_dispatch:
     inputs:
       release:
@@ -151,6 +149,7 @@ jobs:
       - uses: zowe-actions/shared-actions/docker-manifest@main
         with:
           linux-distro: ubuntu
+          primary-linux-distro: ubuntu
           cpu-arch-list: "amd64 s390x"
         timeout-minutes: 2
 
@@ -178,6 +177,7 @@ jobs:
       - uses: zowe-actions/shared-actions/docker-manifest@main
         with:
           linux-distro: ubi
+          primary-linux-distro: ubuntu
           cpu-arch-list: "amd64 s390x"
         timeout-minutes: 2
     

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -138,6 +138,8 @@ jobs:
       - uses: zowe-actions/shared-actions/prepare-workflow@main
 
       - uses: zowe-actions/shared-actions/docker-prepare@main
+        env:
+          ZLUX_DOWNLOAD_API_TOKEN: ${{ secrets.ZLUX_API_TOKEN }}
         with:
           registry-user: ${{ secrets.ARTIFACTORY_X_USERNAME }}
           registry-password: ${{ secrets.ARTIFACTORY_X_PASSWORD }}
@@ -163,6 +165,8 @@ jobs:
       - uses: zowe-actions/shared-actions/prepare-workflow@main
 
       - uses: zowe-actions/shared-actions/docker-prepare@main
+        env:
+          ZLUX_DOWNLOAD_API_TOKEN: ${{ secrets.ZLUX_API_TOKEN }}
         with:
           registry-user: ${{ secrets.ARTIFACTORY_X_USERNAME }}
           registry-password: ${{ secrets.ARTIFACTORY_X_PASSWORD }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -18,7 +18,7 @@ env:
   IMAGE_BASE_DIR: container
 
 jobs:
-  build-amd64-ubuntu:
+  build-ubuntu-amd64:
     runs-on: ubuntu-latest
     
     steps:
@@ -44,7 +44,7 @@ jobs:
         timeout-minutes: 5
 
 
-  build-amd64-ubi:
+  build-ubi-amd64:
     runs-on: ubuntu-latest
     
     steps:
@@ -69,7 +69,7 @@ jobs:
           build-arg-list: ZOWE_BASE_IMAGE=latest-ubi
         timeout-minutes: 5
 
-  build-s390x-ubuntu:
+  build-ubuntu-s390x:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -98,7 +98,7 @@ jobs:
         timeout-minutes: 10
 
 
-  build-s390x-ubi:
+  build-ubi-s390x:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,10 +7,15 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ staging ]
+  workflow_dispatch:
+    inputs:
+      release:
+        description: 'Whether this is a test build or official release'
+        required: true
+        default: false
 
 env:
   IMAGE_BASE_DIR: container
-  RELEASE: true
 
 jobs:
   build-amd64-ubuntu:
@@ -27,7 +32,7 @@ jobs:
         with:
           registry-user: ${{ secrets.ARTIFACTORY_X_USERNAME }}
           registry-password: ${{ secrets.ARTIFACTORY_X_PASSWORD }}
-          release: ${{ env.RELEASE }}
+          release: ${{ github.event.inputs.release }}
           base-directory: ${{ env.IMAGE_BASE_DIR }}
           image-name: app-server
           linux-distro: ubuntu
@@ -53,7 +58,7 @@ jobs:
         with:
           registry-user: ${{ secrets.ARTIFACTORY_X_USERNAME }}
           registry-password: ${{ secrets.ARTIFACTORY_X_PASSWORD }}
-          release: ${{ env.RELEASE }}
+          release: ${{ github.event.inputs.release }}
           base-directory: ${{ env.IMAGE_BASE_DIR }}
           image-name: app-server
           linux-distro: ubi
@@ -77,7 +82,7 @@ jobs:
         with:
           registry-user: ${{ secrets.ARTIFACTORY_X_USERNAME }}
           registry-password: ${{ secrets.ARTIFACTORY_X_PASSWORD }}
-          release: ${{ env.RELEASE }}
+          release: ${{ github.event.inputs.release }}
           base-directory: ${{ env.IMAGE_BASE_DIR }}
           image-name: app-server
           linux-distro: ubuntu
@@ -106,7 +111,7 @@ jobs:
         with:
           registry-user: ${{ secrets.ARTIFACTORY_X_USERNAME }}
           registry-password: ${{ secrets.ARTIFACTORY_X_PASSWORD }}
-          release: ${{ env.RELEASE }}
+          release: ${{ github.event.inputs.release }}
           base-directory: ${{ env.IMAGE_BASE_DIR }}
           image-name: app-server
           linux-distro: ubi
@@ -121,3 +126,54 @@ jobs:
           build-arg-list: ZOWE_BASE_IMAGE=latest-ubi
         timeout-minutes: 10
 
+
+  define-ubuntu-manifest:
+    needs:
+      - build-ubuntu-amd64
+      - build-ubuntu-s390x
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: zowe-actions/shared-actions/prepare-workflow@main
+
+      - uses: zowe-actions/shared-actions/docker-prepare@main
+        with:
+          registry-user: ${{ secrets.ARTIFACTORY_X_USERNAME }}
+          registry-password: ${{ secrets.ARTIFACTORY_X_PASSWORD }}
+          release: ${{ github.event.inputs.release }}
+          base-directory: ${{ env.IMAGE_BASE_DIR }}
+          image-name: app-server
+          linux-distro: ubuntu
+
+      - uses: zowe-actions/shared-actions/docker-manifest@main
+        with:
+          linux-distro: ubuntu
+          cpu-arch-list: "amd64 s390x"
+        timeout-minutes: 2
+
+  define-ubi-manifest:
+    needs:
+      - build-ubi-amd64
+      - build-ubi-s390x
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: zowe-actions/shared-actions/prepare-workflow@main
+
+      - uses: zowe-actions/shared-actions/docker-prepare@main
+        with:
+          registry-user: ${{ secrets.ARTIFACTORY_X_USERNAME }}
+          registry-password: ${{ secrets.ARTIFACTORY_X_PASSWORD }}
+          release: ${{ github.event.inputs.release }}
+          base-directory: ${{ env.IMAGE_BASE_DIR }}
+          image-name: app-server
+          linux-distro: ubi
+
+      - uses: zowe-actions/shared-actions/docker-manifest@main
+        with:
+          linux-distro: ubi
+          cpu-arch-list: "amd64 s390x"
+        timeout-minutes: 2
+    

--- a/container/prepare.sh
+++ b/container/prepare.sh
@@ -42,6 +42,9 @@ if [ -z "${cpu_arch}" ]; then
   exit 1
 fi
 
+echo "Printing env"
+env
+
 ################################################################################
 # CONSTANTS
 # this should be containers/zowe-launch-scripts

--- a/container/prepare.sh
+++ b/container/prepare.sh
@@ -42,9 +42,6 @@ if [ -z "${cpu_arch}" ]; then
   exit 1
 fi
 
-echo "Printing env"
-env
-
 ################################################################################
 # CONSTANTS
 # this should be containers/zowe-launch-scripts
@@ -79,7 +76,6 @@ fi
 if [ -z "${ZLUX_DOWNLOAD_API_TOKEN}" ]; then
   echo "*** WARNING: This will not download patterned URLs without environment variable ZLUX_DOWNLOAD_API_TOKEN. Set with for example export ZLUX_DOWNLOAD_API_TOKEN=... ***"
 fi
-
 
 ./download-zlux.sh
 


### PR DESCRIPTION
Add manifest when building docker containers which means that s390x and amd64 builds will share common tags, and there will be multiple tags for the same version of something such as ubuntu build perhaps having:
latest
latest-ubuntu
latest-ubuntu-1.24.0
etc.