### PR TITLE
use v12.18.4 instead of v12.16.1

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -54,7 +54,7 @@ ARTIFACTORY_REPO = "libs-snapshot-local/org/zowe/zlux"
 PAX_HOSTNAME = "zzow04.zowe.marist.cloud"
 PAX_SSH_PORT = 22
 PAX_CREDENTIALS = "ssh-marist-server-credential"
-NODE_VERSION = "v12.16.1"
+NODE_VERSION = "v12.18.4"
 USER_EMAIL = "zowe-robot@zowe.org"
 USER_NAME = "Zowe Robot"
 


### PR DESCRIPTION
<!-- Thank you for submitting a PR to Zowe! To help us understand, test, and give feedback on your code, please fill in the details below. -->

node v12.16.1 is not stable, try v12.18.4.

The purpose is to solve an issue caused by npm install using v12.16.1, which has peaked the CPU usage on marist server to 100% subsequently results in a server stuck.