### PR TITLE
Dont remove node_modules

### DIFF
--- a/build_ng2.xml
+++ b/build_ng2.xml
@@ -73,7 +73,7 @@
           <include name="**/.*"/>
           <include name="**/node_modules"/>
           <include name="**/dco-signoffs"/>
-          <exclude name="zlux-app-manager/system-apps/**/node_modules/**"/>
+          <exclude name="zlux-app-manager/system-apps/*/lib/node_modules"/>
           <exclude name="zlux-app-server/node_modules/**"/>
           <exclude name="zlux-server-framework/node_modules/**"/>
         </dirset>

--- a/build_ng2.xml
+++ b/build_ng2.xml
@@ -73,6 +73,7 @@
           <include name="**/.*"/>
           <include name="**/node_modules"/>
           <include name="**/dco-signoffs"/>
+          <exclude name="zlux-app-manager/system-apps/**/node_modules/**"/>
           <exclude name="zlux-app-server/node_modules/**"/>
           <exclude name="zlux-server-framework/node_modules/**"/>
         </dirset>
@@ -82,7 +83,6 @@
           <include name="**/nodeServer"/>
           <include name="**/webClient"/>
           <exclude name="**/zssServer/**"/>
-          <exclude name="zlux-app-manager/system-apps/**/node_modules/**"/>
           <exclude name="zlux-app-manager/virtual-desktop/**"/>
           <exclude name="zlux-platform/interface/**"/>
           <exclude name="zlux-app-server/node_modules/**"/>

--- a/build_ng2.xml
+++ b/build_ng2.xml
@@ -82,6 +82,7 @@
           <include name="**/nodeServer"/>
           <include name="**/webClient"/>
           <exclude name="**/zssServer/**"/>
+          <exclude name="zlux-app-manager/system-apps/**/node_modules/**"/>
           <exclude name="zlux-app-manager/virtual-desktop/**"/>
           <exclude name="zlux-platform/interface/**"/>
           <exclude name="zlux-app-server/node_modules/**"/>


### PR DESCRIPTION
web-browser-app appears to ship without node_modules in the proxy service, causing the plugin to not be able to install.
I believe its because the removesource removes it.