### PR TITLE
Dont remove node_modules

### DIFF
--- a/build_ng2.xml
+++ b/build_ng2.xml
@@ -74,6 +74,7 @@
           <include name="**/node_modules"/>
           <include name="**/dco-signoffs"/>
           <exclude name="zlux-app-server/node_modules/**"/>
+          <exclude name="zlux-app-manager/system-apps/**/node_modules/**"/>
           <exclude name="zlux-server-framework/node_modules/**"/>
         </dirset>
         <dirset dir="${capstone}" defaultexcludes="false">

--- a/build_ng2.xml
+++ b/build_ng2.xml
@@ -74,7 +74,7 @@
           <include name="**/node_modules"/>
           <include name="**/dco-signoffs"/>
           <exclude name="zlux-app-server/node_modules/**"/>
-          <exclude name="zlux-app-manager/system-apps/**/node_modules/**"/>
+          <exclude name="zlux-app-manager/system-apps/*/lib/node_modules"/>
           <exclude name="zlux-server-framework/node_modules/**"/>
         </dirset>
         <dirset dir="${capstone}" defaultexcludes="false">


### PR DESCRIPTION
web-browser-app appears to ship without node_modules in the proxy service, causing the plugin to not be able to install.
I believe its because the removesource removes it.