### PR TITLE
Remove app-generator from build output

### DIFF
--- a/build_ng2.xml
+++ b/build_ng2.xml
@@ -78,6 +78,9 @@
           <exclude name="zlux-server-framework/node_modules/**"/>
         </dirset>
         <dirset dir="${capstone}" defaultexcludes="false">
+          <include name="zlux-app-manager/system-apps/app-generator/**"/>
+        </dirset>
+        <dirset dir="${capstone}" defaultexcludes="false">
           <include name="**/src"/>
           <include name="**/dts"/>
           <include name="**/nodeServer"/>


### PR DESCRIPTION
App generator was an app that was presented, but never adopted, and so it fell out of being built.
Yet, its source has been shipped for a while. I'm not sure if it's even functional at this time. I'd rather remove the source from the build output since it has no reason to be there.