### PR TITLE
Update v3 containers build

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -38,8 +38,6 @@ jobs:
           cpu-arch: amd64
       
       - uses: zowe-actions/shared-actions/docker-build-local@main
-        with:
-          build-arg-list: ZOWE_BASE_IMAGE=latest-ubuntu
         timeout-minutes: 5
 
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -63,8 +63,6 @@ jobs:
           cpu-arch: amd64
       
       - uses: zowe-actions/shared-actions/docker-build-local@main
-        with:
-          build-arg-list: ZOWE_BASE_IMAGE=latest-ubi
         timeout-minutes: 5
 
   build-ubuntu-s390x:
@@ -93,7 +91,6 @@ jobs:
           zlinux-ssh-user: ${{ secrets.ZLINUX_SSH_USER }}
           zlinux-ssh-key: ${{ secrets.ZLINUX_SSH_KEY }}
           zlinux-ssh-passphrase: ${{ secrets.ZLINUX_SSH_PASSPHRASE }}
-          build-arg-list: ZOWE_BASE_IMAGE=latest-ubuntu
         timeout-minutes: 10
 
 
@@ -123,7 +120,6 @@ jobs:
           zlinux-ssh-user: ${{ secrets.ZLINUX_SSH_USER }}
           zlinux-ssh-key: ${{ secrets.ZLINUX_SSH_KEY }}
           zlinux-ssh-passphrase: ${{ secrets.ZLINUX_SSH_PASSPHRASE }}
-          build-arg-list: ZOWE_BASE_IMAGE=latest-ubi
         timeout-minutes: 10
 
 

--- a/container/Dockerfile.zlux
+++ b/container/Dockerfile.zlux
@@ -10,7 +10,7 @@
 #                                                                                       #
 #########################################################################################
 # base image tag
-ARG ZOWE_BASE_IMAGE=latest-ubuntu
+ARG ZOWE_BASE_IMAGE=3-ubuntu
 
 FROM zowe-docker-release.jfrog.io/ompzowe/base-node:${ZOWE_BASE_IMAGE} AS builder
 
@@ -52,12 +52,12 @@ USER zowe
 RUN if [ ! -d ${ZWED_INSTALL_DIR}/share/zlux-app-server ]; then cd ${ZWED_INSTALL_DIR}/share && tar -xf zlux-core.tar; fi
 
 RUN cd ${ZWED_INSTALL_DIR}/share/zlux-app-server/bin && \
-chmod +x *.sh && \
-./install-container.sh
+      chmod +x *.sh && \
+      ./install-container.sh
 
 # remove default explorer-ip plugin json 
 RUN if [ -f ${ZWED_INSTALL_DIR}/share/zlux-app-server/defaults/plugins/org.zowe.explorer-ip.json ]; \
-then rm ${ZWED_INSTALL_DIR}/share/zlux-app-server/defaults/plugins/org.zowe.explorer-ip.json; fi
+      then rm ${ZWED_INSTALL_DIR}/share/zlux-app-server/defaults/plugins/org.zowe.explorer-ip.json; fi
 
 WORKDIR ${ZWED_INSTALL_DIR}/bin
 CMD ["./start-container.sh"]


### PR DESCRIPTION
This updates the container builds to use the 3-ubuntu rather than latest-ubuntu base image. The latest tag was not specific to any major version, so this tightens the container build while still allowing some flexibility - new v3 container base images will replace 3-ubuntu, so it acts like a latest tag with a better scope.

There is a matching PR for v2.