### PR TITLE
Update action versions for workflows

### DIFF
--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -137,7 +137,7 @@ jobs:
     steps:
 
       - name: '[Prep 1] Cache node modules'
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           # npm cache files are stored in `~/.npm` on Linux/macOS
           path: |
@@ -149,12 +149,12 @@ jobs:
             ${{ runner.os }}-build-cache-node-modules-
       
       - name: '[Prep 2] Setup Node'
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
-          node-version: 16.15.0
+          node-version: 22.12.0
 
       - name: '[Prep 3] Setup jFrog CLI'
-        uses: jfrog/setup-jfrog-cli@v2
+        uses: jfrog/setup-jfrog-cli@v4
         env:
           JF_ARTIFACTORY_1: ${{ secrets.JF_ARTIFACTORY_TOKEN }}
 

--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -151,7 +151,7 @@ jobs:
       - name: '[Prep 2] Setup Node'
         uses: actions/setup-node@v4
         with:
-          node-version: 22.12.0
+          node-version: 16.15.0
 
       - name: '[Prep 3] Setup jFrog CLI'
         uses: jfrog/setup-jfrog-cli@v4

--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -154,7 +154,7 @@ jobs:
           node-version: 16.15.0
 
       - name: '[Prep 3] Setup jFrog CLI'
-        uses: jfrog/setup-jfrog-cli@v4
+        uses: jfrog/setup-jfrog-cli@v2
         env:
           JF_ARTIFACTORY_1: ${{ secrets.JF_ARTIFACTORY_TOKEN }}
 

--- a/.github/workflows/rc-build.yml
+++ b/.github/workflows/rc-build.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
 
       - name: '[Prep 1] Cache node modules'
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           # npm cache files are stored in `~/.npm` on Linux/macOS
           path: |
@@ -36,12 +36,12 @@ jobs:
             ${{ runner.os }}-build-cache-node-modules-
       
       - name: '[Prep 2] Setup Node'
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
-          node-version: 16.15.0
+          node-version: 22.12.0
 
       - name: '[Prep 3] Setup jFrog CLI'
-        uses: jfrog/setup-jfrog-cli@v2
+        uses: jfrog/setup-jfrog-cli@v4
         env:
           JF_ARTIFACTORY_1: ${{ secrets.JF_ARTIFACTORY_TOKEN }}
 

--- a/.github/workflows/rc-build.yml
+++ b/.github/workflows/rc-build.yml
@@ -38,7 +38,7 @@ jobs:
       - name: '[Prep 2] Setup Node'
         uses: actions/setup-node@v4
         with:
-          node-version: 22.12.0
+          node-version: 16.15.0
 
       - name: '[Prep 3] Setup jFrog CLI'
         uses: jfrog/setup-jfrog-cli@v4

--- a/.github/workflows/rc-build.yml
+++ b/.github/workflows/rc-build.yml
@@ -41,7 +41,7 @@ jobs:
           node-version: 16.15.0
 
       - name: '[Prep 3] Setup jFrog CLI'
-        uses: jfrog/setup-jfrog-cli@v4
+        uses: jfrog/setup-jfrog-cli@v2
         env:
           JF_ARTIFACTORY_1: ${{ secrets.JF_ARTIFACTORY_TOKEN }}
 


### PR DESCRIPTION
The Github actions are automatically failing because it uses a deprecated version of both  `actions/cache@v2` `actions/setup-node@v2`. I have upgraded both to version 4. 