### PR TITLE
Cleanup test certs from output

### DIFF
--- a/build_ng2.xml
+++ b/build_ng2.xml
@@ -81,6 +81,7 @@
         </dirset>
         <dirset dir="${capstone}" defaultexcludes="false">
           <include name="*/test"/>
+          <include name="*/*.ppf"/>
         </dirset>
         <dirset dir="${capstone}" defaultexcludes="false">
           <include name="**/src"/>

--- a/build_ng2.xml
+++ b/build_ng2.xml
@@ -116,8 +116,8 @@
           <include name="**/*.cer"/>
           <include name="**/*.key"/>
           <include name="**/*.p12"/>
-          <include name="zlux-server-framework/defaults/serverConfig/generate_zlux_certificates.sh"/>
-          <include name="zlux-server-framework/defaults/README.md"/>
+          <include name="zlux-app-server/defaults/serverConfig/generate_zlux_certificates.sh"/>
+          <include name="zlux-app-server/defaults/README.md"/>
         </fileset>
       </path>
       <sequential>

--- a/build_ng2.xml
+++ b/build_ng2.xml
@@ -109,6 +109,11 @@
           <exclude name="zlux-platform/interface/**"/>
           <exclude name="zlux-shared/src/**"/>
         </fileset>
+        <fileset dir="${capstone}" defaultexcludes="false">
+          <include name="**/*.cer"/>
+          <include name="**/*.key"/>
+          <include name="**/*.p12"/>
+        </fileset>
       </path>
       <sequential>
         <delete dir="@{path}"/>

--- a/build_ng2.xml
+++ b/build_ng2.xml
@@ -80,6 +80,9 @@
           <include name="zlux-app-manager/system-apps/app-generator/**"/>
         </dirset>
         <dirset dir="${capstone}" defaultexcludes="false">
+          <include name="*/test"/>
+        </dirset>
+        <dirset dir="${capstone}" defaultexcludes="false">
           <include name="**/src"/>
           <include name="**/dts"/>
           <include name="**/nodeServer"/>
@@ -113,6 +116,8 @@
           <include name="**/*.cer"/>
           <include name="**/*.key"/>
           <include name="**/*.p12"/>
+          <include name="zlux-server-framework/defaults/serverConfig/generate_zlux_certificates.sh"/>
+          <include name="zlux-server-framework/defaults/README.md"/>
         </fileset>
       </path>
       <sequential>


### PR DESCRIPTION
Prevents several non-production files from being included in the shipped archives:

**Removed before tar and pax** (via `removeSource` ant target in `build_ng2.xml`, runs on Linux):
- `*.cer`, `*.key`, `*.p12` — TLS certificate and key files from `zlux-server-framework` test fixtures
- `defaults/serverConfig/generate_zlux_certificates.sh` — certificate generation helper script
- `defaults/README.md` — developer-facing readme not needed at runtime
- `*/test` — top-level test directories (e.g., `zlux-server-framework/test`, `zlux-shared/test`); only the first-level `test` folder of each repo is removed, not any deeper nested test directories

**Removed before pax only** (via z/OS shell step in `make-pax` and `core/package` `pax.js`, runs on z/OS):
- `*.bat` — Windows batch scripts have no place in a z/OS pax archive

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
Trigger a full build and verify the resulting `zlux.pax` / `zlux.tar` no longer contains any `*.cer`, `*.key`, or `*.p12` files. The existing `removeSource` step runs on Linux before the tar is created, so the files will be absent from all downstream artifacts.

## Further comments
The affected files are test TLS certificates and private keys used by `zlux-server-framework` tests and development. They carry no runtime value in a production installation and should not be shipped.
