### PR TITLE
V2: Cleanup test certs from output

### DIFF
--- a/build_ng2.xml
+++ b/build_ng2.xml
@@ -81,6 +81,10 @@
           <include name="zlux-app-manager/system-apps/app-generator/**"/>
         </dirset>
         <dirset dir="${capstone}" defaultexcludes="false">
+          <include name="*/test"/>
+          <include name="*/*.ppf"/>
+        </dirset>
+        <dirset dir="${capstone}" defaultexcludes="false">
           <include name="**/src"/>
           <include name="**/dts"/>
           <include name="**/nodeServer"/>
@@ -109,6 +113,13 @@
           <exclude name="zlux-app-manager/virtual-desktop/**"/>
           <exclude name="zlux-platform/interface/**"/>
           <exclude name="zlux-shared/src/**"/>
+        </fileset>
+        <fileset dir="${capstone}" defaultexcludes="false">
+          <include name="**/*.cer"/>
+          <include name="**/*.key"/>
+          <include name="**/*.p12"/>
+          <include name="zlux-app-server/defaults/serverConfig/generate_zlux_certificates.sh"/>
+          <include name="zlux-app-server/defaults/README.md"/>
         </fileset>
       </path>
       <sequential>


### PR DESCRIPTION
V2 version of #165 

Seems to be removing requested files:
```log
2026-05-18T11:42:31.2285666Z    [delete] Deleting: /home/runner/work/zlux-build/zlux-build/dist/zlux-app-server/defaults/serverConfig/apiml-localca.cer
2026-05-18T11:42:31.2287762Z    [delete] Deleting: /home/runner/work/zlux-build/zlux-build/dist/zlux-app-server/defaults/serverConfig/generate_zlux_certificates.sh
2026-05-18T11:42:31.2289371Z    [delete] Deleting: /home/runner/work/zlux-build/zlux-build/dist/zlux-app-server/defaults/serverConfig/zlux.keystore.cer
2026-05-18T11:42:31.2290884Z    [delete] Deleting: /home/runner/work/zlux-build/zlux-build/dist/zlux-app-server/defaults/serverConfig/zlux.keystore.key
2026-05-18T11:42:31.2292402Z    [delete] Deleting: /home/runner/work/zlux-build/zlux-build/dist/zlux-app-server/defaults/serverConfig/zlux.keystore.p12
2026-05-18T11:42:31.2293913Z    [delete] Deleting: /home/runner/work/zlux-build/zlux-build/dist/zlux-app-server/defaults/serverConfig/zlux.truststore.p12
2026-05-18T11:42:31.2295515Z    [delete] Deleting: /home/runner/work/zlux-build/zlux-build/dist/zlux-app-server/deploy/instance/ZLUX/serverConfig/apiml-localca.cer
2026-05-18T11:42:31.2297458Z    [delete] Deleting: /home/runner/work/zlux-build/zlux-build/dist/zlux-app-server/deploy/instance/ZLUX/serverConfig/zlux.keystore.cer
2026-05-18T11:42:31.2299387Z    [delete] Deleting: /home/runner/work/zlux-build/zlux-build/dist/zlux-app-server/deploy/instance/ZLUX/serverConfig/zlux.keystore.key
```