### PR TITLE
Update deprecated GitHub Actions

### DIFF
--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -219,7 +219,7 @@ jobs:
           JF_ARTIFACTORY_1: ${{ secrets.JF_ARTIFACTORY_TOKEN }}
 
       - name: '[Prep 5] prepare workflow'
-        uses: zowe-actions/zlux-builds/core/prepare@v3.x/main
+        uses: zowe-actions/zlux-builds/core/prepare@main
         with:
           github-user: ${{ secrets.ZOWE_ROBOT_USER }}
           github-password: ${{ secrets.ZOWE_ROBOT_TOKEN }}
@@ -243,7 +243,7 @@ jobs:
             ${{ runner.os }}-npm-
 
       - name: '[Prep 7] build'
-        uses: zowe-actions/zlux-builds/core/build@v3.x/main
+        uses: zowe-actions/zlux-builds/core/build@main
         with:
           zlux-app-manager: ${{ env.ZLUX_APP_MANAGER }}
           zlux-app-server: ${{ env.ZLUX_APP_SERVER }}
@@ -253,12 +253,12 @@ jobs:
           zlux-shared: ${{ env.ZLUX_SHARED }}
 
       - name: '[Prep 8] packaging'
-        uses: zowe-actions/zlux-builds/core/package@v3.x/main
+        uses: zowe-actions/zlux-builds/core/package@main
         with:
           pax-ssh-username: ${{ secrets.SSH_MARIST_USERNAME }}
           pax-ssh-password: ${{ secrets.SSH_MARIST_RACF_PASSWORD }}
           pax-name: zlux-core
           
       - name: '[Prep 9] deploy'
-        uses: zowe-actions/zlux-builds/core/deploy@v3.x/main
+        uses: zowe-actions/zlux-builds/core/deploy@main
         

--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -93,7 +93,7 @@ jobs:
       check_commit: ${{ steps.check-changelog.outputs.check_commit }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v2
         with:
           ref: ${{ github.head_ref }}
           fetch-depth: 0
@@ -158,7 +158,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v2
 
       - name: Verify Changelog update
         run: |
@@ -202,7 +202,7 @@ jobs:
           fi
 
       - name: '[Prep 1] Checkout'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v2
 
       - name: '[Prep 2] Validate package.json'
         uses: zowe-actions/shared-actions/validate-package-json@main
@@ -219,7 +219,7 @@ jobs:
           JF_ARTIFACTORY_1: ${{ secrets.JF_ARTIFACTORY_TOKEN }}
 
       - name: '[Prep 5] prepare workflow'
-        uses: zowe-actions/zlux-builds/core/prepare@main
+        uses: zowe-actions/zlux-builds/core/prepare@v3.x/main
         with:
           github-user: ${{ secrets.ZOWE_ROBOT_USER }}
           github-password: ${{ secrets.ZOWE_ROBOT_TOKEN }}
@@ -243,7 +243,7 @@ jobs:
             ${{ runner.os }}-npm-
 
       - name: '[Prep 7] build'
-        uses: zowe-actions/zlux-builds/core/build@main
+        uses: zowe-actions/zlux-builds/core/build@v3.x/main
         with:
           zlux-app-manager: ${{ env.ZLUX_APP_MANAGER }}
           zlux-app-server: ${{ env.ZLUX_APP_SERVER }}
@@ -253,12 +253,12 @@ jobs:
           zlux-shared: ${{ env.ZLUX_SHARED }}
 
       - name: '[Prep 8] packaging'
-        uses: zowe-actions/zlux-builds/core/package@main
+        uses: zowe-actions/zlux-builds/core/package@v3.x/main
         with:
           pax-ssh-username: ${{ secrets.SSH_MARIST_USERNAME }}
           pax-ssh-password: ${{ secrets.SSH_MARIST_RACF_PASSWORD }}
           pax-name: zlux-core
           
       - name: '[Prep 9] deploy'
-        uses: zowe-actions/zlux-builds/core/deploy@main
+        uses: zowe-actions/zlux-builds/core/deploy@v3.x/main
         

--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -93,7 +93,7 @@ jobs:
       check_commit: ${{ steps.check-changelog.outputs.check_commit }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref }}
           fetch-depth: 0
@@ -158,7 +158,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Verify Changelog update
         run: |
@@ -202,7 +202,7 @@ jobs:
           fi
 
       - name: '[Prep 1] Checkout'
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: '[Prep 2] Validate package.json'
         uses: zowe-actions/shared-actions/validate-package-json@main

--- a/.github/workflows/docker-source.yml
+++ b/.github/workflows/docker-source.yml
@@ -20,7 +20,7 @@ jobs:
 
 #      - uses: zowe-actions/shared-actions/envvars-global@main
         
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v4
         with:
           node-version: '12'
           

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       
       - uses: zowe-actions/shared-actions/prepare-workflow@main
       
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       
       - uses: zowe-actions/shared-actions/prepare-workflow@main
       
@@ -68,7 +68,7 @@ jobs:
   build-ubuntu-s390x:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       
       - uses: zowe-actions/shared-actions/prepare-workflow@main
 
@@ -97,7 +97,7 @@ jobs:
   build-ubi-s390x:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       
       - uses: zowe-actions/shared-actions/prepare-workflow@main
 
@@ -129,7 +129,7 @@ jobs:
       - build-ubuntu-s390x
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - uses: zowe-actions/shared-actions/prepare-workflow@main
 
@@ -158,7 +158,7 @@ jobs:
       - build-ubi-s390x
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - uses: zowe-actions/shared-actions/prepare-workflow@main
 

--- a/.github/workflows/rc-build.yml
+++ b/.github/workflows/rc-build.yml
@@ -36,7 +36,7 @@ jobs:
             ${{ runner.os }}-build-cache-node-modules-
       
       - name: '[Prep 2] Setup Node'
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18
 


### PR DESCRIPTION
Resolves zowe/security-reports#2502

Updates deprecated action versions that run on EOL Node.js runtimes and no longer receive security fixes:

actions/checkout@v2 → actions/checkout@v4
actions/setup-node@v2 → actions/setup-node@v4
actions/setup-node@v3 → actions/setup-node@v4