### PR TITLE
Update deprecated GitHub Actions V2

### DIFF
--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -54,7 +54,7 @@ jobs:
       check_commit: ${{ steps.check-changelog.outputs.check_commit }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref }}
           fetch-depth: 0
@@ -119,7 +119,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Verify Changelog update
         run: |

--- a/.github/workflows/docker-source.yml
+++ b/.github/workflows/docker-source.yml
@@ -20,7 +20,7 @@ jobs:
 
 #      - uses: zowe-actions/shared-actions/envvars-global@main
         
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v4
         with:
           node-version: '12'
           

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,7 +6,7 @@ on:
       branch:
         description: 'Please enter the zowe-install-packaging branch name'
         required: false
-        default: 'v2.x/staging'
+        default: 'v3.x/staging'
       release:
         description: 'Whether this is a test build or official release'
         required: true
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       
       - uses: zowe-actions/shared-actions/prepare-workflow@main
       
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       
       - uses: zowe-actions/shared-actions/prepare-workflow@main
       
@@ -68,7 +68,7 @@ jobs:
   build-ubuntu-s390x:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       
       - uses: zowe-actions/shared-actions/prepare-workflow@main
 
@@ -97,7 +97,7 @@ jobs:
   build-ubi-s390x:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       
       - uses: zowe-actions/shared-actions/prepare-workflow@main
 
@@ -129,7 +129,7 @@ jobs:
       - build-ubuntu-s390x
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - uses: zowe-actions/shared-actions/prepare-workflow@main
 
@@ -158,7 +158,7 @@ jobs:
       - build-ubi-s390x
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - uses: zowe-actions/shared-actions/prepare-workflow@main
 


### PR DESCRIPTION
Resolves zowe/security-reports#2502

Updates deprecated action versions that run on EOL Node.js runtimes and no longer receive security fixes:

actions/checkout@v2 → actions/checkout@v4
actions/setup-node@v2 → actions/setup-node@v4
actions/setup-node@v3 → actions/setup-node@v4