### PR TITLE
GitHub Actions to immutable commit SHAs and update EOL Node versions V2

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"

--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -40,7 +40,7 @@ jobs:
     steps:
       # this action will fail the whole workflow if permission check fails
       - name: check permission
-        uses: zowe-actions/shared-actions/permission-check@main
+        uses: zowe-actions/shared-actions/permission-check@77d7d9b50e60fedc8132b5e5eb6d611c4e483416 # main
         with:
           user: ${{ github.actor }}
           github-repo: ${{ github.repository }}
@@ -54,7 +54,7 @@ jobs:
       check_commit: ${{ steps.check-changelog.outputs.check_commit }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ github.head_ref }}
           fetch-depth: 0
@@ -119,7 +119,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Verify Changelog update
         run: |
@@ -137,7 +137,7 @@ jobs:
     steps:
 
       - name: '[Prep 1] Cache node modules'
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           # npm cache files are stored in `~/.npm` on Linux/macOS
           path: |
@@ -149,17 +149,17 @@ jobs:
             ${{ runner.os }}-build-cache-node-modules-
       
       - name: '[Prep 2] Setup Node'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: 16.15.0
+          node-version: 22
 
       - name: '[Prep 3] Setup jFrog CLI'
-        uses: jfrog/setup-jfrog-cli@v2
+        uses: jfrog/setup-jfrog-cli@11ee3f9bb82595485cb55670e4f93885080e183b # v2
         env:
           JF_ARTIFACTORY_1: ${{ secrets.JF_ARTIFACTORY_TOKEN }}
 
       - name: '[Prep 4] prepare workflow'
-        uses: zowe-actions/zlux-builds/core/prepare@v2.x/main
+        uses: zowe-actions/zlux-builds/core/prepare@e3dd3b0261a84f53bfec96ede073ebda45fe4326 # v2.x/main
         with:
           github-user: ${{ secrets.ZOWE_ROBOT_USER }}
           github-password: ${{ secrets.ZOWE_ROBOT_TOKEN }}
@@ -168,7 +168,7 @@ jobs:
           default-base: ${{ github.event.inputs.DEFAULT_BRANCH }}
 
       - name: '[Prep 5] build'
-        uses: zowe-actions/zlux-builds/core/build@v2.x/main
+        uses: zowe-actions/zlux-builds/core/build@e3dd3b0261a84f53bfec96ede073ebda45fe4326 # v2.x/main
         with:
           zlux-app-manager: ${{ github.event.inputs.ZLUX_APP_MANAGER }}
           zlux-app-server: ${{ github.event.inputs.ZLUX_APP_SERVER }}
@@ -178,12 +178,12 @@ jobs:
           zlux-shared: ${{ github.event.inputs.ZLUX_SHARED }}
 
       - name: '[Prep 6] packaging'
-        uses: zowe-actions/zlux-builds/core/package@v2.x/main
+        uses: zowe-actions/zlux-builds/core/package@e3dd3b0261a84f53bfec96ede073ebda45fe4326 # v2.x/main
         with:
           pax-ssh-username: ${{ secrets.SSH_MARIST_USERNAME }}
           pax-ssh-password: ${{ secrets.SSH_MARIST_RACF_PASSWORD }}
           pax-name: zlux-core
           
       - name: '[Prep 7] deploy'
-        uses: zowe-actions/zlux-builds/core/deploy@v2.x/main
+        uses: zowe-actions/zlux-builds/core/deploy@e3dd3b0261a84f53bfec96ede073ebda45fe4326 # v2.x/main
         

--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -54,7 +54,7 @@ jobs:
       check_commit: ${{ steps.check-changelog.outputs.check_commit }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref }}
           fetch-depth: 0
@@ -119,7 +119,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Verify Changelog update
         run: |

--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -134,6 +134,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     needs: check-permission
+    env:
+      NODE_OPTIONS: --openssl-legacy-provider
     steps:
 
       - name: '[Prep 1] Cache node modules'

--- a/.github/workflows/docker-source.yml
+++ b/.github/workflows/docker-source.yml
@@ -20,7 +20,7 @@ jobs:
 
 #      - uses: zowe-actions/shared-actions/envvars-global@main
         
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v4
         with:
           node-version: '12'
           

--- a/.github/workflows/docker-source.yml
+++ b/.github/workflows/docker-source.yml
@@ -20,18 +20,18 @@ jobs:
 
 #      - uses: zowe-actions/shared-actions/envvars-global@main
         
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: '12'
+          node-version: '22'
           
-      - uses: zowe-actions/shared-actions/docker-sources-local@feature/get-docker-sources
+      - uses: zowe-actions/shared-actions/docker-sources-local@3795300c3afc541c8a361e6dad233cbde697aeb5 # feature/get-docker-sources
         with:
           image-name: zowe-docker-snapshot.jfrog.io/ompzowe/app-server:${{ github.event.inputs.image_tag }}
           node-version: ${{ github.event.inputs.node_version }}
           registry-user: ${{ secrets.ARTIFACTORY_USERNAME }}
           registry-password: ${{ secrets.ARTIFACTORY_PASSWORD }}
 
-      - uses: zowe-actions/shared-actions/docker-build-local@feature/get-docker-sources
+      - uses: zowe-actions/shared-actions/docker-build-local@3795300c3afc541c8a361e6dad233cbde697aeb5 # feature/get-docker-sources
         env:
           IMAGE_DIRECTORY: ${{ github.workspace }}/docker-build-local
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,7 +6,7 @@ on:
       branch:
         description: 'Please enter the zowe-install-packaging branch name'
         required: false
-        default: 'v2.x/staging'
+        default: 'v3.x/staging'
       release:
         description: 'Whether this is a test build or official release'
         required: true
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       
       - uses: zowe-actions/shared-actions/prepare-workflow@main
       
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       
       - uses: zowe-actions/shared-actions/prepare-workflow@main
       
@@ -68,7 +68,7 @@ jobs:
   build-ubuntu-s390x:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       
       - uses: zowe-actions/shared-actions/prepare-workflow@main
 
@@ -97,7 +97,7 @@ jobs:
   build-ubi-s390x:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       
       - uses: zowe-actions/shared-actions/prepare-workflow@main
 
@@ -129,7 +129,7 @@ jobs:
       - build-ubuntu-s390x
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - uses: zowe-actions/shared-actions/prepare-workflow@main
 
@@ -158,7 +158,7 @@ jobs:
       - build-ubi-s390x
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - uses: zowe-actions/shared-actions/prepare-workflow@main
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,11 +20,11 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       
-      - uses: zowe-actions/shared-actions/prepare-workflow@main
+      - uses: zowe-actions/shared-actions/prepare-workflow@77d7d9b50e60fedc8132b5e5eb6d611c4e483416 # main
       
-      - uses: zowe-actions/shared-actions/docker-prepare@main
+      - uses: zowe-actions/shared-actions/docker-prepare@77d7d9b50e60fedc8132b5e5eb6d611c4e483416 # main
         env:
           ZLUX_DOWNLOAD_API_TOKEN: ${{ secrets.ZLUX_API_TOKEN }}
           ZLUX_BRANCH: ${{ github.event.inputs.branch }}
@@ -37,7 +37,7 @@ jobs:
           linux-distro: ubuntu
           cpu-arch: amd64
       
-      - uses: zowe-actions/shared-actions/docker-build-local@main
+      - uses: zowe-actions/shared-actions/docker-build-local@77d7d9b50e60fedc8132b5e5eb6d611c4e483416 # main
         timeout-minutes: 5
 
 
@@ -45,11 +45,11 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       
-      - uses: zowe-actions/shared-actions/prepare-workflow@main
+      - uses: zowe-actions/shared-actions/prepare-workflow@77d7d9b50e60fedc8132b5e5eb6d611c4e483416 # main
       
-      - uses: zowe-actions/shared-actions/docker-prepare@main
+      - uses: zowe-actions/shared-actions/docker-prepare@77d7d9b50e60fedc8132b5e5eb6d611c4e483416 # main
         env:
           ZLUX_DOWNLOAD_API_TOKEN: ${{ secrets.ZLUX_API_TOKEN }}
           ZLUX_BRANCH: ${{ github.event.inputs.branch }}
@@ -62,17 +62,17 @@ jobs:
           linux-distro: ubi
           cpu-arch: amd64
       
-      - uses: zowe-actions/shared-actions/docker-build-local@main
+      - uses: zowe-actions/shared-actions/docker-build-local@77d7d9b50e60fedc8132b5e5eb6d611c4e483416 # main
         timeout-minutes: 5
 
   build-ubuntu-s390x:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       
-      - uses: zowe-actions/shared-actions/prepare-workflow@main
+      - uses: zowe-actions/shared-actions/prepare-workflow@77d7d9b50e60fedc8132b5e5eb6d611c4e483416 # main
 
-      - uses: zowe-actions/shared-actions/docker-prepare@main
+      - uses: zowe-actions/shared-actions/docker-prepare@77d7d9b50e60fedc8132b5e5eb6d611c4e483416 # main
         env:
           ZLUX_DOWNLOAD_API_TOKEN: ${{ secrets.ZLUX_API_TOKEN }}
           ZLUX_BRANCH: ${{ github.event.inputs.branch }}
@@ -85,7 +85,7 @@ jobs:
           linux-distro: ubuntu
           cpu-arch: s390x
 
-      - uses: zowe-actions/shared-actions/docker-build-zlinux@main
+      - uses: zowe-actions/shared-actions/docker-build-zlinux@77d7d9b50e60fedc8132b5e5eb6d611c4e483416 # main
         with:
           zlinux-host: ${{ secrets.ZLINUX_HOST }}
           zlinux-ssh-user: ${{ secrets.ZLINUX_SSH_USER }}
@@ -97,11 +97,11 @@ jobs:
   build-ubi-s390x:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       
-      - uses: zowe-actions/shared-actions/prepare-workflow@main
+      - uses: zowe-actions/shared-actions/prepare-workflow@77d7d9b50e60fedc8132b5e5eb6d611c4e483416 # main
 
-      - uses: zowe-actions/shared-actions/docker-prepare@main
+      - uses: zowe-actions/shared-actions/docker-prepare@77d7d9b50e60fedc8132b5e5eb6d611c4e483416 # main
         env:
           ZLUX_DOWNLOAD_API_TOKEN: ${{ secrets.ZLUX_API_TOKEN }}
           ZLUX_BRANCH: ${{ github.event.inputs.branch }}
@@ -114,7 +114,7 @@ jobs:
           linux-distro: ubi
           cpu-arch: s390x
 
-      - uses: zowe-actions/shared-actions/docker-build-zlinux@main
+      - uses: zowe-actions/shared-actions/docker-build-zlinux@77d7d9b50e60fedc8132b5e5eb6d611c4e483416 # main
         with:
           zlinux-host: ${{ secrets.ZLINUX_HOST }}
           zlinux-ssh-user: ${{ secrets.ZLINUX_SSH_USER }}
@@ -129,11 +129,11 @@ jobs:
       - build-ubuntu-s390x
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: zowe-actions/shared-actions/prepare-workflow@main
+      - uses: zowe-actions/shared-actions/prepare-workflow@77d7d9b50e60fedc8132b5e5eb6d611c4e483416 # main
 
-      - uses: zowe-actions/shared-actions/docker-prepare@main
+      - uses: zowe-actions/shared-actions/docker-prepare@77d7d9b50e60fedc8132b5e5eb6d611c4e483416 # main
         env:
           ZLUX_DOWNLOAD_API_TOKEN: ${{ secrets.ZLUX_API_TOKEN }}
           ZLUX_BRANCH: ${{ github.event.inputs.branch }}
@@ -145,7 +145,7 @@ jobs:
           image-name: app-server
           linux-distro: ubuntu
 
-      - uses: zowe-actions/shared-actions/docker-manifest@main
+      - uses: zowe-actions/shared-actions/docker-manifest@77d7d9b50e60fedc8132b5e5eb6d611c4e483416 # main
         with:
           linux-distro: ubuntu
           primary-linux-distro: ubuntu
@@ -158,11 +158,11 @@ jobs:
       - build-ubi-s390x
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: zowe-actions/shared-actions/prepare-workflow@main
+      - uses: zowe-actions/shared-actions/prepare-workflow@77d7d9b50e60fedc8132b5e5eb6d611c4e483416 # main
 
-      - uses: zowe-actions/shared-actions/docker-prepare@main
+      - uses: zowe-actions/shared-actions/docker-prepare@77d7d9b50e60fedc8132b5e5eb6d611c4e483416 # main
         env:
           ZLUX_DOWNLOAD_API_TOKEN: ${{ secrets.ZLUX_API_TOKEN }}
           ZLUX_BRANCH: ${{ github.event.inputs.branch }}
@@ -174,7 +174,7 @@ jobs:
           image-name: app-server
           linux-distro: ubi
 
-      - uses: zowe-actions/shared-actions/docker-manifest@main
+      - uses: zowe-actions/shared-actions/docker-manifest@77d7d9b50e60fedc8132b5e5eb6d611c4e483416 # main
         with:
           linux-distro: ubi
           primary-linux-distro: ubuntu

--- a/.github/workflows/rc-build.yml
+++ b/.github/workflows/rc-build.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       # this action will fail the whole workflow if permission check fails
       - name: check permission
-        uses: zowe-actions/shared-actions/permission-check@main
+        uses: zowe-actions/shared-actions/permission-check@77d7d9b50e60fedc8132b5e5eb6d611c4e483416 # main
         with:
           user: ${{ github.actor }}
           github-repo: ${{ github.repository }}
@@ -24,7 +24,7 @@ jobs:
     steps:
 
       - name: '[Prep 1] Cache node modules'
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           # npm cache files are stored in `~/.npm` on Linux/macOS
           path: |
@@ -36,17 +36,17 @@ jobs:
             ${{ runner.os }}-build-cache-node-modules-
       
       - name: '[Prep 2] Setup Node'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: 16.15.0
+          node-version: 22
 
       - name: '[Prep 3] Setup jFrog CLI'
-        uses: jfrog/setup-jfrog-cli@v2
+        uses: jfrog/setup-jfrog-cli@11ee3f9bb82595485cb55670e4f93885080e183b # v2
         env:
           JF_ARTIFACTORY_1: ${{ secrets.JF_ARTIFACTORY_TOKEN }}
 
       - name: '[Prep 4] prepare workflow'
-        uses: zowe-actions/zlux-builds/core/prepare@v2.x/rc
+        uses: zowe-actions/zlux-builds/core/prepare@2a6a0753dc29882b40c5bff1e078eb638d440241 # v2.x/rc
         with:
           github-user: ${{ secrets.ZOWE_ROBOT_USER }}
           github-password: ${{ secrets.ZOWE_ROBOT_TOKEN }}
@@ -55,14 +55,14 @@ jobs:
           zowe-version: ${{ github.event.inputs.ZOWE_VERSION }}
 
       - name: '[Prep 5] build'
-        uses: zowe-actions/zlux-builds/core/build@v2.x/rc
+        uses: zowe-actions/zlux-builds/core/build@2a6a0753dc29882b40c5bff1e078eb638d440241 # v2.x/rc
 
       - name: '[Prep 6] packaging'
-        uses: zowe-actions/zlux-builds/core/package@v2.x/rc
+        uses: zowe-actions/zlux-builds/core/package@2a6a0753dc29882b40c5bff1e078eb638d440241 # v2.x/rc
         with:
           pax-ssh-username: ${{ secrets.SSH_MARIST_USERNAME }}
           pax-ssh-password: ${{ secrets.SSH_MARIST_RACF_PASSWORD }}
           pax-name: zlux-core
 
       - name: '[Prep 7] deploy'
-        uses: zowe-actions/zlux-builds/core/deploy@v2.x/rc
+        uses: zowe-actions/zlux-builds/core/deploy@2a6a0753dc29882b40c5bff1e078eb638d440241 # v2.x/rc

--- a/.github/workflows/rc-build.yml
+++ b/.github/workflows/rc-build.yml
@@ -21,6 +21,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     needs: check-permission
+    env:
+      NODE_OPTIONS: --openssl-legacy-provider
     steps:
 
       - name: '[Prep 1] Cache node modules'


### PR DESCRIPTION
Resolves security findings from pen test.

- Pin all third-party GitHub Actions to commit SHAs instead of mutable branch/tag refs
- Upgrade Node.js from 18/12 (EOL) to 22 (active LTS)
- Upgrade actions/checkout from v2 to v4