### PR TITLE
Relocate dev-only auth plugins to dev-plugins directory during production builds

### DIFF
--- a/scripts/bash/build_ng2.sh
+++ b/scripts/bash/build_ng2.sh
@@ -199,6 +199,12 @@ remove_source() {
     local capstone="${CAPSTONE}"
     echo "==> removeSource: removing development files from ${capstone} ..."
 
+    # Remove devPlugins directory (development-only auth plugins).
+    if [[ -d "${capstone}/zlux-server-framework/devPlugins" ]]; then
+        echo "Removing devPlugins/"
+        rm -rf "${capstone}/zlux-server-framework/devPlugins"
+    fi
+
     # Excludes that must be preserved.
     local server_nm="${capstone}/zlux-app-server/node_modules"
     local framework_nm="${capstone}/zlux-server-framework/node_modules"

--- a/scripts/powershell/build_ng2.ps1
+++ b/scripts/powershell/build_ng2.ps1
@@ -148,6 +148,13 @@ function Invoke-BuildNg2 {
 function Invoke-RemoveSource {
     Write-Host "==> removeSource: removing development files from ${Capstone} ..."
 
+    # Remove devPlugins directory (development-only auth plugins).
+    $devPluginsDir = Join-Path $Capstone "zlux-server-framework\devPlugins"
+    if (Test-Path $devPluginsDir) {
+        Write-Host "Removing devPlugins/"
+        Remove-Item -Recurse -Force $devPluginsDir
+    }
+
     $serverNm    = Join-Path $Capstone "zlux-app-server\node_modules"
     $frameworkNm = Join-Path $Capstone "zlux-server-framework\node_modules"
 

--- a/scripts/zsh/build_ng2.zsh
+++ b/scripts/zsh/build_ng2.zsh
@@ -140,6 +140,12 @@ remove_source() {
     local capstone="${CAPSTONE}"
     echo "==> removeSource: removing development files from ${capstone} ..."
 
+    # Remove devPlugins directory (development-only auth plugins).
+    if [[ -d "${capstone}/zlux-server-framework/devPlugins" ]]; then
+        echo "Removing devPlugins/"
+        rm -rf "${capstone}/zlux-server-framework/devPlugins"
+    fi
+
     local server_nm="${capstone}/zlux-app-server/node_modules"
     local framework_nm="${capstone}/zlux-server-framework/node_modules"
 


### PR DESCRIPTION
Moves trivial-auth and internal-auth out of the production plugins directory during the removeSource build phase, placing them in `zlux-server-framework/dev-plugins/` instead.

These plugins are development/troubleshooting tools that should not ship in production distributions. Rather than removing them from the source repo, the build now relocates them so they are excluded from the deployable plugins path but remain accessible for development use.

### Changes
- `scripts/bash/build_ng2.sh` — added dev plugin relocation step to `remove_source()`
- `scripts/powershell/build_ng2.ps1` — added dev plugin relocation step to `Invoke-RemoveSource`
- `scripts/zsh/build_ng2.zsh` — added dev plugin relocation step to `remove_source()`

