### PR TITLE
Harden container build supply chain and apply least-privilege workflow permissions

### DIFF
--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -73,9 +73,13 @@ on:
         required: false
         default: v3.x/staging
 
+permissions: {}
+
 jobs:
   check-permission:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       # this action will fail the whole workflow if permission check fails
       - name: check permission
@@ -88,6 +92,8 @@ jobs:
   update-changelog:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     outputs:
       was_updated: ${{ steps.check-change.outputs.change_detected }}
       check_commit: ${{ steps.check-changelog.outputs.check_commit }}
@@ -156,6 +162,8 @@ jobs:
     if: github.event_name == 'pull_request'
     needs: update-changelog
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
@@ -173,6 +181,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     needs: check-permission
+    permissions:
+      contents: read
     env:
       SOURCE_REPO: ${{ inputs.SOURCE_REPO }}
       SOURCE_PR: ${{ inputs.SOURCE_PR }}

--- a/.github/workflows/docker-source.yml
+++ b/.github/workflows/docker-source.yml
@@ -9,6 +9,9 @@ on:
         description: 'Version of nodejs included in the build, ex: 12.19.0'
         required: true
 
+permissions:
+  contents: read
+
 env:
   ZOWE_DOCKER_REGISTRY: zowe-docker-snapshot.jfrog.io
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,6 +12,9 @@ on:
         required: true
         default: false
 
+permissions:
+  contents: read
+
 env:
   IMAGE_BASE_DIR: container
 

--- a/.github/workflows/rc-build.yml
+++ b/.github/workflows/rc-build.yml
@@ -6,6 +6,9 @@ on:
         description: 'Please enter the Zowe version you want to build'
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   check-permission:
     runs-on: ubuntu-latest

--- a/container/Dockerfile.zlux
+++ b/container/Dockerfile.zlux
@@ -11,8 +11,8 @@
 #########################################################################################
 # base image tag
 ARG ZOWE_BASE_IMAGE=3-ubuntu
-
-FROM zowe-docker-release.jfrog.io/ompzowe/base-node:${ZOWE_BASE_IMAGE} AS builder
+ARG ZOWE_BASE_IMAGE_REFERENCE=zowe-docker-release.jfrog.io/ompzowe/base-node:${ZOWE_BASE_IMAGE}
+FROM ${ZOWE_BASE_IMAGE_REFERENCE} AS builder
 
 ##################################
 # labels

--- a/container/build.sh
+++ b/container/build.sh
@@ -13,6 +13,12 @@
 #########################################################################################
 
 mkdir -p logs
-docker pull zowe-docker-release.jfrog.io/ompzowe/base-node:$ZOWE_BASE_IMAGE
-docker build --pull -f Dockerfile.zlux --no-cache --progress=plain --build-arg ZOWE_BASE_IMAGE=$ZOWE_BASE_IMAGE -t zowe-docker-snapshot.jfrog.io/ompzowe/app-server:testing . 2>&1 | tee logs/docker-build.log
+if [ -n "$ZOWE_BASE_IMAGE_DIGEST" ]; then
+  ZOWE_BASE_IMAGE_REFERENCE="zowe-docker-release.jfrog.io/ompzowe/base-node@${ZOWE_BASE_IMAGE_DIGEST}"
+  docker pull "$ZOWE_BASE_IMAGE_REFERENCE"
+  docker build --pull -f Dockerfile.zlux --no-cache --progress=plain --build-arg ZOWE_BASE_IMAGE_REFERENCE="$ZOWE_BASE_IMAGE_REFERENCE" -t zowe-docker-snapshot.jfrog.io/ompzowe/app-server:testing . 2>&1 | tee logs/docker-build.log
+else
+  docker pull zowe-docker-release.jfrog.io/ompzowe/base-node:$ZOWE_BASE_IMAGE
+  docker build --pull -f Dockerfile.zlux --no-cache --progress=plain --build-arg ZOWE_BASE_IMAGE=$ZOWE_BASE_IMAGE -t zowe-docker-snapshot.jfrog.io/ompzowe/app-server:testing . 2>&1 | tee logs/docker-build.log
+fi
 

--- a/container/download-zlux.sh
+++ b/container/download-zlux.sh
@@ -23,10 +23,27 @@ URLS=($(echo $URLS | sed "s/,/ /g"))
 
 for i in "${!URLS[@]}";
 do
-  # echo package zlux/"${PACKAGES[i]}".tar
   echo url "${URLS[i]}"
-  curl -sL "${URLS[i]}" -o files/zlux/"${PACKAGES[i]}".tar && echo "${PACKAGES[i]} done" &
+  curl -fSL "${URLS[i]}" -o "files/zlux/${PACKAGES[i]}.tar" && echo "${PACKAGES[i]} downloaded" &
+  curl -fSL "${URLS[i]}.sha256" -o "files/zlux/${PACKAGES[i]}.tar.sha256" 2>/dev/null &
 done
 wait
+
+# Verify checksums for all downloaded artifacts
+for i in "${!PACKAGES[@]}"; do
+  TARBALL="files/zlux/${PACKAGES[i]}.tar"
+  CHECKSUM_FILE="${TARBALL}.sha256"
+  if [ -f "$CHECKSUM_FILE" ]; then
+    EXPECTED=$(cat "$CHECKSUM_FILE" | tr -d '[:space:]')
+    ACTUAL=$(sha256sum "$TARBALL" | awk '{print $1}')
+    if [ "$EXPECTED" != "$ACTUAL" ]; then
+      echo "ERROR: Checksum mismatch for ${PACKAGES[i]}. Expected: $EXPECTED, Got: $ACTUAL"
+      exit 1
+    fi
+    echo "Checksum verified for ${PACKAGES[i]}"
+  else
+    echo "WARNING: No .sha256 checksum file available for ${PACKAGES[i]}, skipping verification"
+  fi
+done
 
 mv files/zlux/zlux-core.tar files/zlux-core.tar

--- a/container/pull-zowe-install-artifacts.sh
+++ b/container/pull-zowe-install-artifacts.sh
@@ -25,7 +25,20 @@ rm -rf files/zowe-install-packaging 2>/dev/null
 mkdir -p files/zlux
 
 # clone zowe-install-packaging - copy manifest, files/zlux/config
-git clone --branch "$ZLUX_BRANCH" https://github.com/zowe/zowe-install-packaging  files/zowe-install-packaging
+if [ -n "$ZLUX_MANIFEST_COMMIT" ]; then
+  # Pin to a specific commit for reproducible builds
+  git clone --no-checkout https://github.com/zowe/zowe-install-packaging files/zowe-install-packaging
+  git -C files/zowe-install-packaging checkout "$ZLUX_MANIFEST_COMMIT"
+  ACTUAL_COMMIT=$(git -C files/zowe-install-packaging rev-parse HEAD)
+  if [ "$ACTUAL_COMMIT" != "$ZLUX_MANIFEST_COMMIT" ]; then
+    echo "ERROR: Commit mismatch. Expected $ZLUX_MANIFEST_COMMIT, got $ACTUAL_COMMIT"
+    exit 1
+  fi
+  echo "Checked out zowe-install-packaging at pinned commit $ZLUX_MANIFEST_COMMIT"
+else
+  echo "WARNING: ZLUX_MANIFEST_COMMIT not set. Cloning branch tip (mutable). Set ZLUX_MANIFEST_COMMIT for reproducible builds."
+  git clone --branch "$ZLUX_BRANCH" --depth 1 https://github.com/zowe/zowe-install-packaging files/zowe-install-packaging
+fi
 
 # copy manifest to files
 mv files/zowe-install-packaging/manifest.json.template files/manifest.json


### PR DESCRIPTION
Addresses security findings.

- Add explicit permissions: blocks to all GitHub Actions workflows to restrict GITHUB_TOKEN scope
- Replace curl -sL with curl -fSL and add SHA-256 checksum verification for downloaded artifacts
- Support pinning zowe-install-packaging to an immutable commit via ZLUX_MANIFEST_COMMIT
- Support pinning the base container image by digest via ZOWE_BASE_IMAGE_DIGEST