### PR TITLE
Use Artifactory API for SHA-256 verification instead of nonexistent sidecar files

### DIFF
--- a/container/download-zlux.sh
+++ b/container/download-zlux.sh
@@ -25,16 +25,20 @@ for i in "${!URLS[@]}";
 do
   echo url "${URLS[i]}"
   curl -fSL "${URLS[i]}" -o "files/zlux/${PACKAGES[i]}.tar" && echo "${PACKAGES[i]} downloaded" &
-  curl -fSL "${URLS[i]}.sha256" -o "files/zlux/${PACKAGES[i]}.tar.sha256" 2>/dev/null &
 done
 wait
 
-# Verify checksums for all downloaded artifacts
+# Verify checksums via Artifactory REST API (checksums are stored for every artifact)
 for i in "${!PACKAGES[@]}"; do
   TARBALL="files/zlux/${PACKAGES[i]}.tar"
-  CHECKSUM_FILE="${TARBALL}.sha256"
-  if [ -f "$CHECKSUM_FILE" ]; then
-    EXPECTED=$(cat "$CHECKSUM_FILE" | tr -d '[:space:]')
+  # Convert download URL to Artifactory storage API URL for checksum lookup
+  API_URL=$(echo "${URLS[i]}" | sed "s|${ZOWE_REPOSITORY}/|${ZOWE_REPOSITORY}/api/storage/|")
+  EXPECTED=$(curl -fSL "$API_URL" 2>/dev/null | node -e "
+    let d=''; process.stdin.on('data',c=>d+=c); process.stdin.on('end',()=>{
+      try { console.log(JSON.parse(d).checksums.sha256); }
+      catch(e) { process.exit(1); }
+    });" 2>/dev/null)
+  if [ -n "$EXPECTED" ]; then
     ACTUAL=$(sha256sum "$TARBALL" | awk '{print $1}')
     if [ "$EXPECTED" != "$ACTUAL" ]; then
       echo "ERROR: Checksum mismatch for ${PACKAGES[i]}. Expected: $EXPECTED, Got: $ACTUAL"
@@ -42,7 +46,7 @@ for i in "${!PACKAGES[@]}"; do
     fi
     echo "Checksum verified for ${PACKAGES[i]}"
   else
-    echo "WARNING: No .sha256 checksum file available for ${PACKAGES[i]}, skipping verification"
+    echo "WARNING: Could not retrieve checksum from Artifactory API for ${PACKAGES[i]}, skipping verification"
   fi
 done
 

--- a/container/download-zlux.sh
+++ b/container/download-zlux.sh
@@ -17,9 +17,9 @@ set -e
 ZOWE_REPOSITORY=https://zowe.jfrog.io/artifactory
 
 output=$(node getPackagePaths.js)
-read -r PACKAGES URLS <<<$(echo $output | sed "s/;/ /g")
-PACKAGES=($(echo $PACKAGES | sed "s/,/ /g"))
-URLS=($(echo $URLS | sed "s/,/ /g"))
+read -r PACKAGES URLS <<<$(echo "$output" | sed "s/;/ /g")
+PACKAGES=($(echo "$PACKAGES" | sed "s/,/ /g"))
+URLS=($(echo "$URLS" | sed "s/,/ /g"))
 
 for i in "${!URLS[@]}";
 do

--- a/container/download-zlux.sh
+++ b/container/download-zlux.sh
@@ -38,7 +38,7 @@ for i in "${!PACKAGES[@]}"; do
       try { console.log(JSON.parse(d).checksums.sha256); }
       catch(e) { process.exit(1); }
     });" 2>/dev/null)
-  if [ -n "$EXPECTED" ]; then
+  if [[ -n "$EXPECTED" ]]; then
     ACTUAL=$(sha256sum "$TARBALL" | awk '{print $1}')
     if [ "$EXPECTED" != "$ACTUAL" ]; then
       echo "ERROR: Checksum mismatch for ${PACKAGES[i]}. Expected: $EXPECTED, Got: $ACTUAL"

--- a/container/getPackagePaths.js
+++ b/container/getPackagePaths.js
@@ -91,6 +91,10 @@ function sortArtifacts(names){
 
 async function artifactory(name, version, artifact){
 	data = await findArtifact(name, version, artifact);
+	if (!data || !data['results'] || data['results'].length === 0) {
+		console.error(`ERROR: AQL search returned no results for ${name} (version: ${version}, artifact: ${artifact}). Is ZLUX_DOWNLOAD_API_TOKEN valid?`);
+		process.exit(1);
+	}
 	sortArtifacts(data)
 	let results = data['results'][0]['repo'] + '/' + data['results'][0]['path'] + '/' + data['results'][0]['name']
 	return results

--- a/container/getPackagePaths.js
+++ b/container/getPackagePaths.js
@@ -13,7 +13,7 @@
 */
 
 if (!process.env.ZLUX_DOWNLOAD_API_TOKEN) {
-  console.log('*** WARNING: This will not download patterned URLs without environment variable ZLUX_DOWNLOAD_API_TOKEN. Set with for example export ZLUX_DOWNLOAD_API_TOKEN=... ***');
+  console.error('WARNING: This will not download patterned URLs without environment variable ZLUX_DOWNLOAD_API_TOKEN. Set with for example export ZLUX_DOWNLOAD_API_TOKEN=...');
 }
 
 

--- a/container/pull-zowe-install-artifacts.sh
+++ b/container/pull-zowe-install-artifacts.sh
@@ -12,7 +12,7 @@
 #                                                                                       #
 #########################################################################################
 
-if [ -z "$ZLUX_BRANCH" ]; then
+if [[ -z "$ZLUX_BRANCH" ]]; then
 	echo " Default branch will be staging, to change branch please set environment ZLUX_BRANCH. Set with for example export ZLUX_BRANCH=..."
 	export ZLUX_BRANCH="v3.x/staging"
 fi
@@ -25,12 +25,12 @@ rm -rf files/zowe-install-packaging 2>/dev/null
 mkdir -p files/zlux
 
 # clone zowe-install-packaging - copy manifest, files/zlux/config
-if [ -n "$ZLUX_MANIFEST_COMMIT" ]; then
+if [[ -n "$ZLUX_MANIFEST_COMMIT" ]]; then
   # Pin to a specific commit for reproducible builds
   git clone --no-checkout https://github.com/zowe/zowe-install-packaging files/zowe-install-packaging
   git -C files/zowe-install-packaging checkout "$ZLUX_MANIFEST_COMMIT"
   ACTUAL_COMMIT=$(git -C files/zowe-install-packaging rev-parse HEAD)
-  if [ "$ACTUAL_COMMIT" != "$ZLUX_MANIFEST_COMMIT" ]; then
+  if [[ "$ACTUAL_COMMIT" != "$ZLUX_MANIFEST_COMMIT" ]]; then
     echo "ERROR: Commit mismatch. Expected $ZLUX_MANIFEST_COMMIT, got $ACTUAL_COMMIT"
     exit 1
   fi


### PR DESCRIPTION
The previous checksum implementation attempted to download .sha256 sidecar files that don't exist in our Artifactory repos. This switches to querying Artifactory's /api/storage/ endpoint, which returns checksums computed at upload time for every artifact, no changes needed to the upload pipeline.