### PR TITLE
Update zlux-builds hash to pick up v2 curl fix

### DIFF
--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -229,7 +229,7 @@ jobs:
           JF_ARTIFACTORY_1: ${{ secrets.JF_ARTIFACTORY_TOKEN }}
 
       - name: '[Prep 5] prepare workflow'
-        uses: zowe-actions/zlux-builds/core/prepare@013e1aad4515865af81037ba083e56875b8257b2 # v3.x/main
+        uses: zowe-actions/zlux-builds/core/prepare@45cd8dc50de64566783bd0f69ea8ae6de830d69a # v3.x/main
         with:
           github-user: ${{ secrets.ZOWE_ROBOT_USER }}
           github-password: ${{ secrets.ZOWE_ROBOT_TOKEN }}
@@ -253,7 +253,7 @@ jobs:
             ${{ runner.os }}-npm-
 
       - name: '[Prep 7] build'
-        uses: zowe-actions/zlux-builds/core/build@013e1aad4515865af81037ba083e56875b8257b2 # v3.x/main
+        uses: zowe-actions/zlux-builds/core/build@45cd8dc50de64566783bd0f69ea8ae6de830d69a # v3.x/main
         with:
           zlux-app-manager: ${{ env.ZLUX_APP_MANAGER }}
           zlux-app-server: ${{ env.ZLUX_APP_SERVER }}
@@ -263,12 +263,12 @@ jobs:
           zlux-shared: ${{ env.ZLUX_SHARED }}
 
       - name: '[Prep 8] packaging'
-        uses: zowe-actions/zlux-builds/core/package@013e1aad4515865af81037ba083e56875b8257b2 # v3.x/main
+        uses: zowe-actions/zlux-builds/core/package@45cd8dc50de64566783bd0f69ea8ae6de830d69a # v3.x/main
         with:
           pax-ssh-username: ${{ secrets.SSH_MARIST_USERNAME }}
           pax-ssh-password: ${{ secrets.SSH_MARIST_RACF_PASSWORD }}
           pax-name: zlux-core
           
       - name: '[Prep 9] deploy'
-        uses: zowe-actions/zlux-builds/core/deploy@013e1aad4515865af81037ba083e56875b8257b2 # v3.x/main
+        uses: zowe-actions/zlux-builds/core/deploy@45cd8dc50de64566783bd0f69ea8ae6de830d69a # v3.x/main
         


### PR DESCRIPTION
Description:
Update zlux-builds action references from 013e1aad to 45cd8dc5 (v3.x/main).

This picks up the fix in [action.yml](vscode-file://vscode-app/c:/Users/jstruga/AppData/Local/Programs/Microsoft%20VS%20Code/df53daabb1/resources/app/out/vs/code/electron-browser/workbench/workbench.html) where ZOWE_V2_VERSION is now extracted from the org.zowe.zlux.zlux-core binary dependency version (which already includes -RC) instead of the top-level manifest version, fixing the v2 artifact download URL mismatch.